### PR TITLE
Fix luarocks urls

### DIFF
--- a/v2/en/using-luarocks.md
+++ b/v2/en/using-luarocks.md
@@ -4,7 +4,7 @@
     @created       2011-08-07 02:32 GMT
     @modifier      Yichun Zhang
     @modifier_link yichun-zhang
-    @modified      2014-01-25 17:59 GMT
+    @modified      2016-04-11 14:34 UTC
     @changes       36
 --->
 
@@ -26,8 +26,8 @@ If you haven't installed OpenResty yet, check out the [Download](download.html) 
 #  Install LuaRocks
 First of all, let's install LuaRocks:
 
-[Download](download.html) the LuaRocks tarball from [http://www.luarocks.org/en/Download](http://www.luarocks.org/en/-download.html).
-As of this writing, the latest version is `2.1.2`, but we'll use `2.0.13` for
+Download the LuaRocks tarball from [https://luarocks.org/releases](https://luarocks.org/releases).
+As of this writing, the latest version is `2.3.0`, but we'll use `2.0.13` for
 compatibility throughout this sample.
 
 ```


### PR DESCRIPTION
I'm actually testing luarocks 2.3.0 right now with openresty 1.9.7.4 - so far it works (installation + installing rocks and using them in openresty), but I've left that out of the PR.

If 2.3.0 has/gets an official seal of approval, that should be changed as well.