### PR TITLE
typo: Chinese MP4 video 

### DIFF
--- a/v2/en/presentations.md
+++ b/v2/en/presentations.md
@@ -17,7 +17,7 @@ engine based on AJAX.
 
 This presentation was given at the [OpenResty Con 2016](https://con.openresty.org/cn/2016/) conference held in Shenzhen, China.
 
-Video recording (in Chinese): https://youtu.be/H5UFGDaf9Xk  (Visitors from mainland China should access [this MP4 video](openresty.org/videos/openresty-con-2016.mp4) instead)
+Video recording (in Chinese): https://youtu.be/H5UFGDaf9Xk  (Visitors from mainland China should access [this MP4 video](https://openresty.org/videos/openresty-con-2016.mp4) instead)
 
 Download the slides as PDF: https://openresty.org/slides/New-development-of-OpenResty-in-2016.pdf
 


### PR DESCRIPTION
Hello.

@agentzh I'm tasting your 2016 presentations in OpenResty Con:). The [Video recording in Chinese](http://openresty.org/en/presentations.html) now is 404 on [openresty.org](https://openresty.org).