### PR TITLE
Ubuntu 16.04 requires libcurl4-openssl-dev to compile

### DIFF
--- a/v2/en/installation.md
+++ b/v2/en/installation.md
@@ -86,7 +86,7 @@ You're recommended to install the following packages using apt-get:
 
 ```
 apt-get install libreadline-dev libncurses5-dev libpcre3-dev \
-    libssl-dev perl make build-essential
+    libssl-dev libcurl4-openssl-dev perl make build-essential
 ```
 
 


### PR DESCRIPTION
I had to install this package in order to successfully compile.