### PR TITLE
added announcement for OpenResty 1.15.8.1 RC1.

### DIFF
--- a/v2/Makefile
+++ b/v2/Makefile
@@ -30,6 +30,10 @@ tpage = tpage
 .PHONY: all
 all: templates css msgfmt
 
+.PHONY: check
+check:
+	@echo $(md_files)
+
 .PHONY: templates
 templates: $(templates_lua)
 

--- a/v2/cn/ann-1015008001rc1.md
+++ b/v2/cn/ann-1015008001rc1.md
@@ -1,0 +1,195 @@
+<!---
+    @title         OpenResty 1.15.8.1 RC1 is out
+--->
+
+We have just kicked out a new release candidate, OpenResty 1.15.8.1 RC1,
+for the community to test out:
+
+https://openresty.org/download/openresty-1.15.8.1rc1.tar.gz
+
+PGP for this source tar ball:
+
+https://openresty.org/download/openresty-1.15.8.1rc1.tar.gz.asc
+
+Win64 version:
+
+https://openresty.org/download/openresty-1.15.8.1rc1-win64.zip
+
+PGP for the Win64 zip file:
+
+https://openresty.org/download/openresty-1.15.8.1rc1-win64.zip.asc
+
+Win32 version:
+
+https://openresty.org/download/openresty-1.15.8.1rc1-win32.zip
+
+PGP for the Win32 zip file:
+
+https://openresty.org/download/openresty-1.15.8.1rc1-win32.zip.asc
+
+Special thanks go to all our developers and contributors! Also thanks Thibault Charbonnier
+for his great help in preparing this release.
+
+The highlights of this release are:
+
+1. Based on the very recent mainline [nginx](nginx.html) core 1.15.8.
+2. Support for ARM64 architectures. The underlying work for this feature
+allowed to speed up other architectures by up to ~10%.
+3. New lua-resty-shell library for efficiently spawning sub-processes via the
+new ngx.pipe API.
+4. New lua-resty-signal library for killing and sending signals to UNIX
+processes.
+5. New lua-tablepool library for efficiently recycling Lua tables.
+6. We dropped support for the standard Lua 5.1 interpreter, and vividly
+recommend the use of OpenResty's fork of LuaJIT.
+7. [ngx_lua](https://github.com/openresty/lua-nginx-module#readme)
+    * New ngx.pipe API which allows spawning sub-processes and communicating
+    with them in a non-blocking way.
+    * Support for connections backlog queuing in cosockets via the new pool_size
+    and backlog options of the [tcpsock:connect()](https://github.com/openresty/lua-nginx-module#tcpsockconnect) method.
+    * New tcpsock:receiveany() API for BSD-style receive.
+8. [ngx_stream_lua](https://github.com/openresty/stream-lua-nginx-module#readme) module
+    * New reqsock:peek() API for the [ngx_stream_lua](https://github.com/openresty/stream-lua-nginx-module#readme) module, to peek into the
+    preread buffer without consuming the data.
+    * We enabled support for [ssl_certificate_by_lua*](https://github.com/openresty/lua-nginx-module#ssl_certificate_by_lua_block) in the [ngx_stream_lua](https://github.com/openresty/stream-lua-nginx-module#readme)
+    module.
+    * We enabled support for the FFI-based shdict API, [ngx.semaphore](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/semaphore.md#readme), and
+    [ngx.errlog](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/errlog.md#readme).
+9. LuaJIT
+    * We now enable the GC64 mode of LuaJIT by default on x86_64
+    platforms.
+    * Implemented a new [table.isempty()](https://github.com/openresty/luajit2#tableisempty) API.
+    * Implemented a new [table.isarray()](https://github.com/openresty/luajit2#tableisarray) API.
+    * Implemented a new [table.nkeys()](https://github.com/openresty/luajit2#tablenkeys) API.
+
+    All our new Lua API functions documentation can be found here: https://github.com/openresty/luajit2#new-api
+
+Complete change logs since the last (formal) release, 1.13.6.2:
+
+* upgraded the [nginx](nginx.html) core to 1.15.8.
+    * see the changes here: http://nginx.org/en/CHANGES
+* change: we now enable the GC64 mode by default in our bundled LuaJIT build for x86_64 architectures; this can be disabled using `--without-luajit-gc64`. _Thanks Thibault Charbonnier for the patch._
+* feature: bundled the [lua-tablepool](https://github.com/openresty/lua-tablepool#readme) library.
+* feature: bundled the [lua-resty-signal](https://github.com/openresty/lua-resty-signal#readme) library. _Thanks OpenResty Inc. for supporting this work._
+* feature: bundled the [lua-resty-shell](https://github.com/openresty/lua-resty-shell#readme) library. _Thanks OpenResty Inc. for supporting this work._
+* feature: ./configure: added new options `--without-stream_ssl_module` and `--without-stream`.
+* feature: ./configure: added support for the `-h` option.
+* feature: ./configure: support `@rpath` placeholder in OS X. _Thanks Datong Sun for the patch._
+* feature: updated the `socket_cloexec` patches to support the [ngx.pipe](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/pipe.md#readme) API. _Thanks OpenResty Inc. for supporting this work and spacewander for the development of the patch._
+* win32: upgraded openssl to 1.1.0j.
+* bugfix: [nginx](nginx.html) did not destroy the cycle memory pool before the daemon process exits. _Thanks Yuansheng Wang for the patch._
+* resty-doc indexes: skipped nginx's njs docs due to the use of special xml tags.
+* upgraded [ngx_lua](https://github.com/openresty/lua-nginx-module#readme) to 0.10.14.
+    * feature: added support for ARM64 (Aarch64). _Thanks Cloudflare for sponsoring this work. Thanks Dejiang Zhu and Zexuan Luo for the development of the patch._
+    * feature: added the `pool_size` and `backlog` options to the [tcpsock:connect()](https://github.com/openresty/lua-nginx-module#tcpsockconnect) API in order to support backlog queuing in cosocket connection pools. _Thanks OpenResty Inc. for supporting this work and spacewander for the development of the patch._
+    * feature: implemented a new [lua_sa_restart](https://github.com/openresty/lua-nginx-module#lua_sa_restart) directive, which sets the `SA_RESTART` flag on [nginx](nginx.html) workers signal dispositions. _Thanks Thibault Charbonnier for the patch._
+    * feature: implemented the [tcpsock:receiveany()](https://github.com/openresty/lua-nginx-module#tcpsockreceiveany) upstream cosocket API. _Thanks spacewander for the patch._
+    * feature: added support for the [nginx](nginx.html) builtin Link header, which allows for specifying multiple values for this header. _Thanks tokers and Thibault Charbonnier for the patch._
+    * feature: errors are now logged when timers fail to run. _Thanks spacewander for the patch._
+    * feature: added an [FFI](http://luajit.org/ext_ffi.html) API to support the [ngx.pipe](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/pipe.md#readme) API provided by [lua-resty-core](https://github.com/openresty/lua-resty-core#readme). _Thanks OpenResty Inc. for supporting this work and spacewander for the development of the patch._
+    * feature: added an [FFI](http://luajit.org/ext_ffi.html) API for retrieving `env` directives values from [init_by_lua*](https://github.com/openresty/lua-nginx-module#init_by_lua). _Thanks Thibault Charbonnier for the patch._
+    * change: we no longer support the standard Lua 5.1 interpreter (PUC-Rio Lua). It is now strongly recommended to use the OpenResty LuaJIT releases, bundled with the official OpenResty releases.
+    * change: we now avoid running [init_by_lua*](https://github.com/openresty/lua-nginx-module#init_by_lua) in signaller processes and when testing the [nginx](nginx.html) configuration. _Thanks spacewander for the patch._
+    * change: we now print an alert when a non openresty-specific version of LuaJIT is detected since many optimizations would be missing. _Thanks Thibault Charbonnier for the patch._
+    * change: we now print a warning when writing to the Lua global variable `_G`.
+    * change: we now avoid generating the Content-Type response header when getting all response headers. _Thanks spacewander for the patch._
+    * bugfix: fixed a segfault in [nginx](nginx.html) core >= 1.15.0 when [init_worker_by_lua*](https://github.com/openresty/lua-nginx-module#init_worker_by_lua) is used. _Thanks Datong Sun for the patch._
+    * bugfix: [ngx.process](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/process.md#readme): [type()](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/process.md#type) didn't return 'master' in master process. _Thanks spacewander for the patch._
+    * bugfix: [tcpsock:setkeepalive()](https://github.com/openresty/lua-nginx-module#tcpsocksetkeepalive): worker processes might take too long to gracefully shutdown when the keep alive connections take a long max idle time. _Thanks Dejiang Zhu for the patch._
+    * bugfix: setting the request "Host" header should clear any existing cached `$host` variable so that subsequent reads return the expected result.
+    * bugfix: inlined Lua code snippets in `nginx.conf` failed to use the Lua source checksum as part of the Lua code cache key.
+    * bugfix: silenced `-Wcast-function-type` warnings, allowing for compilation with gcc8. _Thanks Alessandro Ghedini for the patch._
+    * doc: noted that [ngx.req.get_method()](https://github.com/openresty/lua-nginx-module#ngxreqget_method) can be used in the [body_filter_by_lua*](https://github.com/openresty/lua-nginx-module#body_filter_by_lua) and [log_by_lua*](https://github.com/openresty/lua-nginx-module#log_by_lua) phases. _Thanks tokers for the patch._
+    * doc: updated the docs to reflect the change that we now no longer support the standard Lua 5.1 interpreter in this module. also recommended OpenResty's LuaJIT branch version instead of the stock LuaJIT.
+    * doc: mention that [ngx.req.set_body_data()](https://github.com/openresty/lua-nginx-module#ngxreqset_body_data) and [ngx.req.set_body_file()](https://github.com/openresty/lua-nginx-module#ngxreqset_body_file) must read the request body. _Thanks Thibault Charbonnier for the patch._
+    * doc: fixed the links to [ssl_session_store_by_lua*](https://github.com/openresty/lua-nginx-module#ssl_session_store_by_lua_block). _Thanks chronolaw for the patch._
+    * typo: fixed a debug log in access and rewrite handlers. _Thanks sbhr for the patch._
+* upgraded [ngx_stream_lua](https://github.com/openresty/stream-lua-nginx-module#readme) to 0.0.6.
+    * feature: added support for ARM64. _Thanks Cloudflare for sponsoring this work. Thanks Dejiang Zhu and Zexuan Luo for the development of the patch._
+    * feature: implemented the preread [reqsock:peek()](https://github.com/openresty/stream-lua-nginx-module#reqsockpeek) API. _Thanks Kong Inc. for sponsoring this work. Thanks Datong Sun for the development of the patch._
+    * feature: enabled [ssl_certificate_by_lua*](https://github.com/openresty/lua-nginx-module#ssl_certificate_by_lua_block) support. _Thanks Kong Inc. for sponsoring the development of this feature, and thanks James Callahan and Datong Sun for the development of the patch._
+    * feature: implemented a new [lua_sa_restart](https://github.com/openresty/lua-nginx-module#lua_sa_restart) directive, which sets the `SA_RESTART` flag on [nginx](nginx.html) workers signal dispositions. _Thanks Thibault Charbonnier for the patch._
+    * feature: enabled resty.core.shdict support. _Thanks Datong Sun for the patch._
+    * feature: enabled [ngx.semaphore](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/semaphore.md#readme) support. _Thanks Datong Sun for the patch._
+    * feature: enabled [ngx.errlog](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/errlog.md#readme) support. _Thanks Thibault Charbonnier for the patch._
+    * feature: added an [FFI](http://luajit.org/ext_ffi.html) API for retrieving `env` directives values from [init_by_lua*](https://github.com/openresty/lua-nginx-module#init_by_lua). _Thanks Thibault Charbonnier for the patch._
+    * change: we now avoid running [init_by_lua*](https://github.com/openresty/lua-nginx-module#init_by_lua) in signaller processes and when testing the [nginx](nginx.html) configuration. _Thanks Thibault Charbonnier for the patch._
+    * change: we now print an alert when a non openresty-specific version of LuaJIT is detected since many optimizations would be missing. _Thanks Thibault Charbonnier for the patch._
+    * misc: re-rendered all files to include newly added template header. _Thanks Datong Sun for the patch._
+    * doc: added missing links for [ssl_certificate_by_lua*](https://github.com/openresty/lua-nginx-module#ssl_certificate_by_lua_block) directives. _Thanks chronolaw for the patch._
+* upgraded [lua-resty-core](https://github.com/openresty/lua-resty-core#readme) to 0.1.16.
+    * feature: added support for ARM64 (AArch64). _Thanks Cloudflare for sponsoring this work. Thanks Dejiang Zhu and Zexuan Luo for the development of the patch._
+    * feature: implemented the [ngx.pipe](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/pipe.md#readme) API which allows spawning processes and communicating with them in a non-blocking way. _Thanks OpenResty Inc. for supporting this work and spacewander for the development of the patch._
+    * feature: [ssl_certificate_by_lua*](https://github.com/openresty/lua-nginx-module#ssl_certificate_by_lua_block) support for the stream subsystem. _Thanks Kong Inc. for sponsoring the development of this feature, and thanks James Callahan and Datong Sun for the development of the patch._
+    * feature: resty.core.shdict: enabled the FFI-based API for the stream subsystem. _Thanks Datong Sun for the patch._
+    * feature: [ngx.semaphore](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/semaphore.md#readme): enabled the FFI-based API for the stream subsystem. _Thanks Datong Sun for the patch._
+    * feature: [ngx.errlog](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/errlog.md#readme): enabled the FFI-based API for the stream subsystem. _Thanks Thibault Charbonnier for the patch._
+    * feature: `os.getenv` is now able to retrieve `env` directives values from within [init_by_lua*](https://github.com/openresty/lua-nginx-module#init_by_lua). _Thanks Thibault Charbonnier for the patch._
+    * change: we now require OpenResty's LuaJIT branch to work properly on ARM64 since we make use of the `thread.exdata` Lua API.
+    * change: increased stack level on subsystem violation error to expose the offending module. _Thanks Datong Sun for the patch._
+    * feature: implemented the `ndk.*` API with [FFI](http://luajit.org/ext_ffi.html).
+    * bugfix: [ngx.process](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/process.md#readme): [type()](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/process.md#type) didn't return 'master' in master process. _Thanks spacewander for the patch._
+    * bugfix: now we only allow a single version of [ngx_lua](https://github.com/openresty/lua-nginx-module#readme) and [ngx_stream_lua](https://github.com/openresty/stream-lua-nginx-module#readme). _Thanks spacewander for the patch._
+    * optimize: fixed misuses of Lua global variables in our Lua code (caught by the new version of the lj-releng tool).
+    * doc: [ngx.process](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/process.md#readme): fixed a typo in the spelling of 'privileged agent'. _Thanks spacewander for the patch._
+    * doc: [ngx.process](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/process.md#readme): updated the process type list. _Thanks spacewander for the patch._
+    * doc: [ngx.balancer](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/balancer.md#readme): fixed a typo in the sample code. _Thanks chronolaw for the patch._
+    * doc: [ngx.ssl](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/ssl.md#readme): documented the `get_tls1_version_str()` API function.
+    * doc: [ngx.semaphore](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/semaphore.md#readme): switch status to production ready.
+* upgraded LuaJIT to 2.1-20190228: https://github.com/openresty/luajit2/tags
+    * feature: implemented a new [table.isempty()](https://github.com/openresty/luajit2/blob/v2.1-agentzh/README) API. _Thanks OpenResty Inc. for supporting this work._
+    * feature: implemented a new [table.isarray()](https://github.com/openresty/luajit2/blob/v2.1-agentzh/README) API. _Thanks OpenResty Inc. for supporting this work._
+    * feature: implemented a new [table.nkeys()](https://github.com/openresty/luajit2/blob/v2.1-agentzh/README) API. _Thanks OpenResty Inc. for supporting this work._
+    * feature: implemented the new Lua and C API functions for [thread.exdata](https://github.com/openresty/luajit2/blob/v2.1-agentzh/README). This API is used internally by the OpenResty and we advise not to use it yourself in the context of OpenResty. _Thanks Zexuan Luo for preparing the final version of the patch._
+    * feature: luajit.h: defined the macro `OPENRESTY_LUAJIT` for our branch of LuaJIT.
+    * change: run the LJ_64 branch in asm_hrefk when LUAJIT_USE_VALGRIND and LUAJIT_ENABLE_GC64 are both supplied. _Thanks spacewander for the patch._
+    * bugfix: `ffi.C.FUNC()`: it lacked a write barrier which might lead to use-after-free issues and memory corruptions.
+    * bugfix: LuaJIT's `jit.v` module might lead to segfaults due to buggy Lua stack traversal code.
+    * bugfix: 16-bit MCLink.mapofs and GCtrace.nsnapmap fields would overflow for large Lua programs, leading to segfaults; enlarged them to 32-bit.
+    * bugfix: fixed assertion failure "lj_record.c:92: rec_check_slots: Assertion `nslots <= 250' failed" found by stressing our edgelang compiler.
+    * doc: documented what we change in our OpenResty branch of LuaJIT.
+    * imported Mike Pall's latest changes:
+        * Improve luaL_addlstring().
+        * Fix os.date() for wider libc strftime() compatibility.
+        * Fix MinGW build.
+        * DynASM/MIPS: Fix shadowed variable.
+        * DynASM/PPC: Fix shadowed variable.
+        * Fix overflow of snapshot map offset.
+        * Better detection of MinGW build.
+        * Actually implement maxirconst trace limit.
+        * MIPS/MIPS64: Fix TSETR barrier (again).
+        * Fix memory probing allocator to check for valid end address, too.
+        * DynASM/x86: Fix vroundps/vroundpd encoding.
+        * DynASM: Fix warning.
+        * ARM64: Fix exit stub patching.
+        * ARM64: Fix write barrier in BC_USETS.
+        * Windows: Add UWP support, part 1.
+        * From Lua 5.3: assert() accepts any type of error object.
+        * x86: Disassemble FMA3 instructions.
+        * DynASM/x86: Add FMA3 instructions.
+        * PPC/NetBSD: Fix endianess check.
+        * x86/x64: Check for jcc when using xor r,r in emit_loadi().
+        * [FFI](http://luajit.org/ext_ffi.html): Make FP to U64 conversions match JIT backend behavior.
+        * Bump copyright date to 2018.
+        * [FFI](http://luajit.org/ext_ffi.html): Add tonumber() specialization for failed conversions.
+        * Give expected results for negative non-base-10 numbers in tonumber().
+* upgraded [lua-resty-lrucache](https://github.com/openresty/lua-resty-lrucache#readme) to 0.09.
+    * optimize: fixed misuses of Lua global variables in our Lua code (caught by the new version of the lj-releng tool).
+* upgraded [lua-resty-lock](https://github.com/openresty/lua-resty-lock#readme) to 0.08.
+    * bugfix: we now enforce the use of lua-resty-core's resty.core.shdict module to avoid dead locking with the CFunction-based shdict API in [ngx_lua](https://github.com/openresty/lua-nginx-module#readme).
+    * doc: made it clearer that we depend on [lua-resty-core](https://github.com/openresty/lua-resty-core#readme).
+    * doc: documented the limitations of certain [ngx_lua](https://github.com/openresty/lua-nginx-module#readme) execution contexts which prohibit yielding.
+* upgraded [lua-resty-limit-traffic](https://github.com/openresty/lua-resty-limit-traffic#readme) to 0.06.
+    * bugfix: set_conn() method did not work at all due to a copy&paste error. _Thanks pearzl for the patch._
+    * doc: added the [resty.limit.count](https://github.com/openresty/lua-resty-limit-traffic/blob/master/lib/resty/limit/count.md#readme) module to the library's README. _Thanks Thibault Charbonnier for the patch._
+* upgraded [resty-cli](https://github.com/openresty/resty-cli#readme) to 0.23.
+    * feature: implemented new `--stap` and `--stap-opts` command-line options to trace the underlying [nginx](nginx.html) C process directly (without going through the Perl wrapper layer).
+    * feature: implemented a new `--main-conf` command-line option for specifying nginx's main {} context directives directly from the command line. _Thanks Datong Sun for the patch._
+    * feature: implemented a new `--gdb-opts` command-line option which implies `--gdb`. The `--valgrind-opts` option also implies `--valgrind`.
+    * bugfix: md2pod: infinite looping might happen when an empty `.md` file is given.
+* upgraded [lua-resty-upstream-healthcheck](https://github.com/openresty/lua-resty-upstream-healthcheck#readme) to 0.06.
+    * bugfix: avoided shadowing a variable which would prevent the checking threads from being waited upon. _Thanks Thijs Schreijer and Thibault Charbonnier for the report and fix._
+
+Feedback welcome!
+
+Thanks!

--- a/v2/cn/ann-1015008001rc1.md.tt2
+++ b/v2/cn/ann-1015008001rc1.md.tt2
@@ -1,0 +1,196 @@
+[% VER = "1.15.8.1"; RC = 1 -%]
+<!---
+    @title         OpenResty [% VER %] RC[% RC %] is out
+--->
+
+We have just kicked out a new release candidate, OpenResty [% VER %] RC[% RC %],
+for the community to test out:
+
+https://openresty.org/download/openresty-[% VER %]rc[% RC %].tar.gz
+
+PGP for this source tar ball:
+
+https://openresty.org/download/openresty-[% VER %]rc[% RC %].tar.gz.asc
+
+Win64 version:
+
+https://openresty.org/download/openresty-[% VER %]rc[% RC %]-win64.zip
+
+PGP for the Win64 zip file:
+
+https://openresty.org/download/openresty-[% VER %]rc[% RC %]-win64.zip.asc
+
+Win32 version:
+
+https://openresty.org/download/openresty-[% VER %]rc[% RC %]-win32.zip
+
+PGP for the Win32 zip file:
+
+https://openresty.org/download/openresty-[% VER %]rc[% RC %]-win32.zip.asc
+
+Special thanks go to all our developers and contributors! Also thanks Thibault Charbonnier
+for his great help in preparing this release.
+
+The highlights of this release are:
+
+1. Based on the very recent mainline [nginx](nginx.html) core 1.15.8.
+2. Support for ARM64 architectures. The underlying work for this feature
+allowed to speed up other architectures by up to ~10%.
+3. New lua-resty-shell library for efficiently spawning sub-processes via the
+new ngx.pipe API.
+4. New lua-resty-signal library for killing and sending signals to UNIX
+processes.
+5. New lua-tablepool library for efficiently recycling Lua tables.
+6. We dropped support for the standard Lua 5.1 interpreter, and vividly
+recommend the use of OpenResty's fork of LuaJIT.
+7. [ngx_lua](https://github.com/openresty/lua-nginx-module#readme)
+    * New ngx.pipe API which allows spawning sub-processes and communicating
+    with them in a non-blocking way.
+    * Support for connections backlog queuing in cosockets via the new pool_size
+    and backlog options of the [tcpsock:connect()](https://github.com/openresty/lua-nginx-module#tcpsockconnect) method.
+    * New tcpsock:receiveany() API for BSD-style receive.
+8. [ngx_stream_lua](https://github.com/openresty/stream-lua-nginx-module#readme) module
+    * New reqsock:peek() API for the [ngx_stream_lua](https://github.com/openresty/stream-lua-nginx-module#readme) module, to peek into the
+    preread buffer without consuming the data.
+    * We enabled support for [ssl_certificate_by_lua*](https://github.com/openresty/lua-nginx-module#ssl_certificate_by_lua_block) in the [ngx_stream_lua](https://github.com/openresty/stream-lua-nginx-module#readme)
+    module.
+    * We enabled support for the FFI-based shdict API, [ngx.semaphore](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/semaphore.md#readme), and
+    [ngx.errlog](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/errlog.md#readme).
+9. LuaJIT
+    * We now enable the GC64 mode of LuaJIT by default on x86_64
+    platforms.
+    * Implemented a new [table.isempty()](https://github.com/openresty/luajit2#tableisempty) API.
+    * Implemented a new [table.isarray()](https://github.com/openresty/luajit2#tableisarray) API.
+    * Implemented a new [table.nkeys()](https://github.com/openresty/luajit2#tablenkeys) API.
+
+    All our new Lua API functions documentation can be found here: https://github.com/openresty/luajit2#new-api
+
+Complete change logs since the last (formal) release, 1.13.6.2:
+
+* upgraded the [nginx](nginx.html) core to 1.15.8.
+    * see the changes here: http://nginx.org/en/CHANGES
+* change: we now enable the GC64 mode by default in our bundled LuaJIT build for x86_64 architectures; this can be disabled using `--without-luajit-gc64`. _Thanks Thibault Charbonnier for the patch._
+* feature: bundled the [lua-tablepool](https://github.com/openresty/lua-tablepool#readme) library.
+* feature: bundled the [lua-resty-signal](https://github.com/openresty/lua-resty-signal#readme) library. _Thanks OpenResty Inc. for supporting this work._
+* feature: bundled the [lua-resty-shell](https://github.com/openresty/lua-resty-shell#readme) library. _Thanks OpenResty Inc. for supporting this work._
+* feature: ./configure: added new options `--without-stream_ssl_module` and `--without-stream`.
+* feature: ./configure: added support for the `-h` option.
+* feature: ./configure: support `@rpath` placeholder in OS X. _Thanks Datong Sun for the patch._
+* feature: updated the `socket_cloexec` patches to support the [ngx.pipe](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/pipe.md#readme) API. _Thanks OpenResty Inc. for supporting this work and spacewander for the development of the patch._
+* win32: upgraded openssl to 1.1.0j.
+* bugfix: [nginx](nginx.html) did not destroy the cycle memory pool before the daemon process exits. _Thanks Yuansheng Wang for the patch._
+* resty-doc indexes: skipped nginx's njs docs due to the use of special xml tags.
+* upgraded [ngx_lua](https://github.com/openresty/lua-nginx-module#readme) to 0.10.14.
+    * feature: added support for ARM64 (Aarch64). _Thanks Cloudflare for sponsoring this work. Thanks Dejiang Zhu and Zexuan Luo for the development of the patch._
+    * feature: added the `pool_size` and `backlog` options to the [tcpsock:connect()](https://github.com/openresty/lua-nginx-module#tcpsockconnect) API in order to support backlog queuing in cosocket connection pools. _Thanks OpenResty Inc. for supporting this work and spacewander for the development of the patch._
+    * feature: implemented a new [lua_sa_restart](https://github.com/openresty/lua-nginx-module#lua_sa_restart) directive, which sets the `SA_RESTART` flag on [nginx](nginx.html) workers signal dispositions. _Thanks Thibault Charbonnier for the patch._
+    * feature: implemented the [tcpsock:receiveany()](https://github.com/openresty/lua-nginx-module#tcpsockreceiveany) upstream cosocket API. _Thanks spacewander for the patch._
+    * feature: added support for the [nginx](nginx.html) builtin Link header, which allows for specifying multiple values for this header. _Thanks tokers and Thibault Charbonnier for the patch._
+    * feature: errors are now logged when timers fail to run. _Thanks spacewander for the patch._
+    * feature: added an [FFI](http://luajit.org/ext_ffi.html) API to support the [ngx.pipe](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/pipe.md#readme) API provided by [lua-resty-core](https://github.com/openresty/lua-resty-core#readme). _Thanks OpenResty Inc. for supporting this work and spacewander for the development of the patch._
+    * feature: added an [FFI](http://luajit.org/ext_ffi.html) API for retrieving `env` directives values from [init_by_lua*](https://github.com/openresty/lua-nginx-module#init_by_lua). _Thanks Thibault Charbonnier for the patch._
+    * change: we no longer support the standard Lua 5.1 interpreter (PUC-Rio Lua). It is now strongly recommended to use the OpenResty LuaJIT releases, bundled with the official OpenResty releases.
+    * change: we now avoid running [init_by_lua*](https://github.com/openresty/lua-nginx-module#init_by_lua) in signaller processes and when testing the [nginx](nginx.html) configuration. _Thanks spacewander for the patch._
+    * change: we now print an alert when a non openresty-specific version of LuaJIT is detected since many optimizations would be missing. _Thanks Thibault Charbonnier for the patch._
+    * change: we now print a warning when writing to the Lua global variable `_G`.
+    * change: we now avoid generating the Content-Type response header when getting all response headers. _Thanks spacewander for the patch._
+    * bugfix: fixed a segfault in [nginx](nginx.html) core >= 1.15.0 when [init_worker_by_lua*](https://github.com/openresty/lua-nginx-module#init_worker_by_lua) is used. _Thanks Datong Sun for the patch._
+    * bugfix: [ngx.process](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/process.md#readme): [type()](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/process.md#type) didn't return 'master' in master process. _Thanks spacewander for the patch._
+    * bugfix: [tcpsock:setkeepalive()](https://github.com/openresty/lua-nginx-module#tcpsocksetkeepalive): worker processes might take too long to gracefully shutdown when the keep alive connections take a long max idle time. _Thanks Dejiang Zhu for the patch._
+    * bugfix: setting the request "Host" header should clear any existing cached `$host` variable so that subsequent reads return the expected result.
+    * bugfix: inlined Lua code snippets in `nginx.conf` failed to use the Lua source checksum as part of the Lua code cache key.
+    * bugfix: silenced `-Wcast-function-type` warnings, allowing for compilation with gcc8. _Thanks Alessandro Ghedini for the patch._
+    * doc: noted that [ngx.req.get_method()](https://github.com/openresty/lua-nginx-module#ngxreqget_method) can be used in the [body_filter_by_lua*](https://github.com/openresty/lua-nginx-module#body_filter_by_lua) and [log_by_lua*](https://github.com/openresty/lua-nginx-module#log_by_lua) phases. _Thanks tokers for the patch._
+    * doc: updated the docs to reflect the change that we now no longer support the standard Lua 5.1 interpreter in this module. also recommended OpenResty's LuaJIT branch version instead of the stock LuaJIT.
+    * doc: mention that [ngx.req.set_body_data()](https://github.com/openresty/lua-nginx-module#ngxreqset_body_data) and [ngx.req.set_body_file()](https://github.com/openresty/lua-nginx-module#ngxreqset_body_file) must read the request body. _Thanks Thibault Charbonnier for the patch._
+    * doc: fixed the links to [ssl_session_store_by_lua*](https://github.com/openresty/lua-nginx-module#ssl_session_store_by_lua_block). _Thanks chronolaw for the patch._
+    * typo: fixed a debug log in access and rewrite handlers. _Thanks sbhr for the patch._
+* upgraded [ngx_stream_lua](https://github.com/openresty/stream-lua-nginx-module#readme) to 0.0.6.
+    * feature: added support for ARM64. _Thanks Cloudflare for sponsoring this work. Thanks Dejiang Zhu and Zexuan Luo for the development of the patch._
+    * feature: implemented the preread [reqsock:peek()](https://github.com/openresty/stream-lua-nginx-module#reqsockpeek) API. _Thanks Kong Inc. for sponsoring this work. Thanks Datong Sun for the development of the patch._
+    * feature: enabled [ssl_certificate_by_lua*](https://github.com/openresty/lua-nginx-module#ssl_certificate_by_lua_block) support. _Thanks Kong Inc. for sponsoring the development of this feature, and thanks James Callahan and Datong Sun for the development of the patch._
+    * feature: implemented a new [lua_sa_restart](https://github.com/openresty/lua-nginx-module#lua_sa_restart) directive, which sets the `SA_RESTART` flag on [nginx](nginx.html) workers signal dispositions. _Thanks Thibault Charbonnier for the patch._
+    * feature: enabled resty.core.shdict support. _Thanks Datong Sun for the patch._
+    * feature: enabled [ngx.semaphore](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/semaphore.md#readme) support. _Thanks Datong Sun for the patch._
+    * feature: enabled [ngx.errlog](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/errlog.md#readme) support. _Thanks Thibault Charbonnier for the patch._
+    * feature: added an [FFI](http://luajit.org/ext_ffi.html) API for retrieving `env` directives values from [init_by_lua*](https://github.com/openresty/lua-nginx-module#init_by_lua). _Thanks Thibault Charbonnier for the patch._
+    * change: we now avoid running [init_by_lua*](https://github.com/openresty/lua-nginx-module#init_by_lua) in signaller processes and when testing the [nginx](nginx.html) configuration. _Thanks Thibault Charbonnier for the patch._
+    * change: we now print an alert when a non openresty-specific version of LuaJIT is detected since many optimizations would be missing. _Thanks Thibault Charbonnier for the patch._
+    * misc: re-rendered all files to include newly added template header. _Thanks Datong Sun for the patch._
+    * doc: added missing links for [ssl_certificate_by_lua*](https://github.com/openresty/lua-nginx-module#ssl_certificate_by_lua_block) directives. _Thanks chronolaw for the patch._
+* upgraded [lua-resty-core](https://github.com/openresty/lua-resty-core#readme) to 0.1.16.
+    * feature: added support for ARM64 (AArch64). _Thanks Cloudflare for sponsoring this work. Thanks Dejiang Zhu and Zexuan Luo for the development of the patch._
+    * feature: implemented the [ngx.pipe](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/pipe.md#readme) API which allows spawning processes and communicating with them in a non-blocking way. _Thanks OpenResty Inc. for supporting this work and spacewander for the development of the patch._
+    * feature: [ssl_certificate_by_lua*](https://github.com/openresty/lua-nginx-module#ssl_certificate_by_lua_block) support for the stream subsystem. _Thanks Kong Inc. for sponsoring the development of this feature, and thanks James Callahan and Datong Sun for the development of the patch._
+    * feature: resty.core.shdict: enabled the FFI-based API for the stream subsystem. _Thanks Datong Sun for the patch._
+    * feature: [ngx.semaphore](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/semaphore.md#readme): enabled the FFI-based API for the stream subsystem. _Thanks Datong Sun for the patch._
+    * feature: [ngx.errlog](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/errlog.md#readme): enabled the FFI-based API for the stream subsystem. _Thanks Thibault Charbonnier for the patch._
+    * feature: `os.getenv` is now able to retrieve `env` directives values from within [init_by_lua*](https://github.com/openresty/lua-nginx-module#init_by_lua). _Thanks Thibault Charbonnier for the patch._
+    * change: we now require OpenResty's LuaJIT branch to work properly on ARM64 since we make use of the `thread.exdata` Lua API.
+    * change: increased stack level on subsystem violation error to expose the offending module. _Thanks Datong Sun for the patch._
+    * feature: implemented the `ndk.*` API with [FFI](http://luajit.org/ext_ffi.html).
+    * bugfix: [ngx.process](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/process.md#readme): [type()](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/process.md#type) didn't return 'master' in master process. _Thanks spacewander for the patch._
+    * bugfix: now we only allow a single version of [ngx_lua](https://github.com/openresty/lua-nginx-module#readme) and [ngx_stream_lua](https://github.com/openresty/stream-lua-nginx-module#readme). _Thanks spacewander for the patch._
+    * optimize: fixed misuses of Lua global variables in our Lua code (caught by the new version of the lj-releng tool).
+    * doc: [ngx.process](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/process.md#readme): fixed a typo in the spelling of 'privileged agent'. _Thanks spacewander for the patch._
+    * doc: [ngx.process](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/process.md#readme): updated the process type list. _Thanks spacewander for the patch._
+    * doc: [ngx.balancer](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/balancer.md#readme): fixed a typo in the sample code. _Thanks chronolaw for the patch._
+    * doc: [ngx.ssl](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/ssl.md#readme): documented the `get_tls1_version_str()` API function.
+    * doc: [ngx.semaphore](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/semaphore.md#readme): switch status to production ready.
+* upgraded LuaJIT to 2.1-20190228: https://github.com/openresty/luajit2/tags
+    * feature: implemented a new [table.isempty()](https://github.com/openresty/luajit2/blob/v2.1-agentzh/README) API. _Thanks OpenResty Inc. for supporting this work._
+    * feature: implemented a new [table.isarray()](https://github.com/openresty/luajit2/blob/v2.1-agentzh/README) API. _Thanks OpenResty Inc. for supporting this work._
+    * feature: implemented a new [table.nkeys()](https://github.com/openresty/luajit2/blob/v2.1-agentzh/README) API. _Thanks OpenResty Inc. for supporting this work._
+    * feature: implemented the new Lua and C API functions for [thread.exdata](https://github.com/openresty/luajit2/blob/v2.1-agentzh/README). This API is used internally by the OpenResty and we advise not to use it yourself in the context of OpenResty. _Thanks Zexuan Luo for preparing the final version of the patch._
+    * feature: luajit.h: defined the macro `OPENRESTY_LUAJIT` for our branch of LuaJIT.
+    * change: run the LJ_64 branch in asm_hrefk when LUAJIT_USE_VALGRIND and LUAJIT_ENABLE_GC64 are both supplied. _Thanks spacewander for the patch._
+    * bugfix: `ffi.C.FUNC()`: it lacked a write barrier which might lead to use-after-free issues and memory corruptions.
+    * bugfix: LuaJIT's `jit.v` module might lead to segfaults due to buggy Lua stack traversal code.
+    * bugfix: 16-bit MCLink.mapofs and GCtrace.nsnapmap fields would overflow for large Lua programs, leading to segfaults; enlarged them to 32-bit.
+    * bugfix: fixed assertion failure "lj_record.c:92: rec_check_slots: Assertion `nslots <= 250' failed" found by stressing our edgelang compiler.
+    * doc: documented what we change in our OpenResty branch of LuaJIT.
+    * imported Mike Pall's latest changes:
+        * Improve luaL_addlstring().
+        * Fix os.date() for wider libc strftime() compatibility.
+        * Fix MinGW build.
+        * DynASM/MIPS: Fix shadowed variable.
+        * DynASM/PPC: Fix shadowed variable.
+        * Fix overflow of snapshot map offset.
+        * Better detection of MinGW build.
+        * Actually implement maxirconst trace limit.
+        * MIPS/MIPS64: Fix TSETR barrier (again).
+        * Fix memory probing allocator to check for valid end address, too.
+        * DynASM/x86: Fix vroundps/vroundpd encoding.
+        * DynASM: Fix warning.
+        * ARM64: Fix exit stub patching.
+        * ARM64: Fix write barrier in BC_USETS.
+        * Windows: Add UWP support, part 1.
+        * From Lua 5.3: assert() accepts any type of error object.
+        * x86: Disassemble FMA3 instructions.
+        * DynASM/x86: Add FMA3 instructions.
+        * PPC/NetBSD: Fix endianess check.
+        * x86/x64: Check for jcc when using xor r,r in emit_loadi().
+        * [FFI](http://luajit.org/ext_ffi.html): Make FP to U64 conversions match JIT backend behavior.
+        * Bump copyright date to 2018.
+        * [FFI](http://luajit.org/ext_ffi.html): Add tonumber() specialization for failed conversions.
+        * Give expected results for negative non-base-10 numbers in tonumber().
+* upgraded [lua-resty-lrucache](https://github.com/openresty/lua-resty-lrucache#readme) to 0.09.
+    * optimize: fixed misuses of Lua global variables in our Lua code (caught by the new version of the lj-releng tool).
+* upgraded [lua-resty-lock](https://github.com/openresty/lua-resty-lock#readme) to 0.08.
+    * bugfix: we now enforce the use of lua-resty-core's resty.core.shdict module to avoid dead locking with the CFunction-based shdict API in [ngx_lua](https://github.com/openresty/lua-nginx-module#readme).
+    * doc: made it clearer that we depend on [lua-resty-core](https://github.com/openresty/lua-resty-core#readme).
+    * doc: documented the limitations of certain [ngx_lua](https://github.com/openresty/lua-nginx-module#readme) execution contexts which prohibit yielding.
+* upgraded [lua-resty-limit-traffic](https://github.com/openresty/lua-resty-limit-traffic#readme) to 0.06.
+    * bugfix: set_conn() method did not work at all due to a copy&paste error. _Thanks pearzl for the patch._
+    * doc: added the [resty.limit.count](https://github.com/openresty/lua-resty-limit-traffic/blob/master/lib/resty/limit/count.md#readme) module to the library's README. _Thanks Thibault Charbonnier for the patch._
+* upgraded [resty-cli](https://github.com/openresty/resty-cli#readme) to 0.23.
+    * feature: implemented new `--stap` and `--stap-opts` command-line options to trace the underlying [nginx](nginx.html) C process directly (without going through the Perl wrapper layer).
+    * feature: implemented a new `--main-conf` command-line option for specifying nginx's main {} context directives directly from the command line. _Thanks Datong Sun for the patch._
+    * feature: implemented a new `--gdb-opts` command-line option which implies `--gdb`. The `--valgrind-opts` option also implies `--valgrind`.
+    * bugfix: md2pod: infinite looping might happen when an empty `.md` file is given.
+* upgraded [lua-resty-upstream-healthcheck](https://github.com/openresty/lua-resty-upstream-healthcheck#readme) to 0.06.
+    * bugfix: avoided shadowing a variable which would prevent the checking threads from being waited upon. _Thanks Thijs Schreijer and Thibault Charbonnier for the report and fix._
+
+Feedback welcome!
+
+Thanks!

--- a/v2/cn/openresty.md
+++ b/v2/cn/openresty.md
@@ -4,6 +4,8 @@
     @created       2011-06-21 04:03 GMT
 --->
 
+***最新！*** [OpenResty 1.15.8.1 RC1](ann-1015008001rc1.html) 已经发布供测试。
+
 OpenResty<sup>&reg;</sup> 是一个基于 [Nginx](nginx.html) 与 Lua 的高性能 Web 平台，其内部集成了大量精良的
 Lua 库、第三方模块以及大多数的依赖项。用于方便地搭建能够处理超高并发、扩展性极高的动态
 Web 应用、Web 服务和动态网关。

--- a/v2/en/ann-1015008001rc1.md
+++ b/v2/en/ann-1015008001rc1.md
@@ -1,0 +1,195 @@
+<!---
+    @title         OpenResty 1.15.8.1 RC1 is out
+--->
+
+We have just kicked out a new release candidate, OpenResty 1.15.8.1 RC1,
+for the community to test out:
+
+https://openresty.org/download/openresty-1.15.8.1rc1.tar.gz
+
+PGP for this source tar ball:
+
+https://openresty.org/download/openresty-1.15.8.1rc1.tar.gz.asc
+
+Win64 version:
+
+https://openresty.org/download/openresty-1.15.8.1rc1-win64.zip
+
+PGP for the Win64 zip file:
+
+https://openresty.org/download/openresty-1.15.8.1rc1-win64.zip.asc
+
+Win32 version:
+
+https://openresty.org/download/openresty-1.15.8.1rc1-win32.zip
+
+PGP for the Win32 zip file:
+
+https://openresty.org/download/openresty-1.15.8.1rc1-win32.zip.asc
+
+Special thanks go to all our developers and contributors! Also thanks Thibault Charbonnier
+for his great help in preparing this release.
+
+The highlights of this release are:
+
+1. Based on the very recent mainline [nginx](nginx.html) core 1.15.8.
+2. Support for ARM64 architectures. The underlying work for this feature
+allowed to speed up other architectures by up to ~10%.
+3. New lua-resty-shell library for efficiently spawning sub-processes via the
+new ngx.pipe API.
+4. New lua-resty-signal library for killing and sending signals to UNIX
+processes.
+5. New lua-tablepool library for efficiently recycling Lua tables.
+6. We dropped support for the standard Lua 5.1 interpreter, and vividly
+recommend the use of OpenResty's fork of LuaJIT.
+7. [ngx_lua](https://github.com/openresty/lua-nginx-module#readme)
+    * New ngx.pipe API which allows spawning sub-processes and communicating
+    with them in a non-blocking way.
+    * Support for connections backlog queuing in cosockets via the new pool_size
+    and backlog options of the [tcpsock:connect()](https://github.com/openresty/lua-nginx-module#tcpsockconnect) method.
+    * New tcpsock:receiveany() API for BSD-style receive.
+8. [ngx_stream_lua](https://github.com/openresty/stream-lua-nginx-module#readme) module
+    * New reqsock:peek() API for the [ngx_stream_lua](https://github.com/openresty/stream-lua-nginx-module#readme) module, to peek into the
+    preread buffer without consuming the data.
+    * We enabled support for [ssl_certificate_by_lua*](https://github.com/openresty/lua-nginx-module#ssl_certificate_by_lua_block) in the [ngx_stream_lua](https://github.com/openresty/stream-lua-nginx-module#readme)
+    module.
+    * We enabled support for the FFI-based shdict API, [ngx.semaphore](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/semaphore.md#readme), and
+    [ngx.errlog](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/errlog.md#readme).
+9. LuaJIT
+    * We now enable the GC64 mode of LuaJIT by default on x86_64
+    platforms.
+    * Implemented a new [table.isempty()](https://github.com/openresty/luajit2#tableisempty) API.
+    * Implemented a new [table.isarray()](https://github.com/openresty/luajit2#tableisarray) API.
+    * Implemented a new [table.nkeys()](https://github.com/openresty/luajit2#tablenkeys) API.
+
+    All our new Lua API functions documentation can be found here: https://github.com/openresty/luajit2#new-api
+
+Complete change logs since the last (formal) release, 1.13.6.2:
+
+* upgraded the [nginx](nginx.html) core to 1.15.8.
+    * see the changes here: http://nginx.org/en/CHANGES
+* change: we now enable the GC64 mode by default in our bundled LuaJIT build for x86_64 architectures; this can be disabled using `--without-luajit-gc64`. _Thanks Thibault Charbonnier for the patch._
+* feature: bundled the [lua-tablepool](https://github.com/openresty/lua-tablepool#readme) library.
+* feature: bundled the [lua-resty-signal](https://github.com/openresty/lua-resty-signal#readme) library. _Thanks OpenResty Inc. for supporting this work._
+* feature: bundled the [lua-resty-shell](https://github.com/openresty/lua-resty-shell#readme) library. _Thanks OpenResty Inc. for supporting this work._
+* feature: ./configure: added new options `--without-stream_ssl_module` and `--without-stream`.
+* feature: ./configure: added support for the `-h` option.
+* feature: ./configure: support `@rpath` placeholder in OS X. _Thanks Datong Sun for the patch._
+* feature: updated the `socket_cloexec` patches to support the [ngx.pipe](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/pipe.md#readme) API. _Thanks OpenResty Inc. for supporting this work and spacewander for the development of the patch._
+* win32: upgraded openssl to 1.1.0j.
+* bugfix: [nginx](nginx.html) did not destroy the cycle memory pool before the daemon process exits. _Thanks Yuansheng Wang for the patch._
+* resty-doc indexes: skipped nginx's njs docs due to the use of special xml tags.
+* upgraded [ngx_lua](https://github.com/openresty/lua-nginx-module#readme) to 0.10.14.
+    * feature: added support for ARM64 (Aarch64). _Thanks Cloudflare for sponsoring this work. Thanks Dejiang Zhu and Zexuan Luo for the development of the patch._
+    * feature: added the `pool_size` and `backlog` options to the [tcpsock:connect()](https://github.com/openresty/lua-nginx-module#tcpsockconnect) API in order to support backlog queuing in cosocket connection pools. _Thanks OpenResty Inc. for supporting this work and spacewander for the development of the patch._
+    * feature: implemented a new [lua_sa_restart](https://github.com/openresty/lua-nginx-module#lua_sa_restart) directive, which sets the `SA_RESTART` flag on [nginx](nginx.html) workers signal dispositions. _Thanks Thibault Charbonnier for the patch._
+    * feature: implemented the [tcpsock:receiveany()](https://github.com/openresty/lua-nginx-module#tcpsockreceiveany) upstream cosocket API. _Thanks spacewander for the patch._
+    * feature: added support for the [nginx](nginx.html) builtin Link header, which allows for specifying multiple values for this header. _Thanks tokers and Thibault Charbonnier for the patch._
+    * feature: errors are now logged when timers fail to run. _Thanks spacewander for the patch._
+    * feature: added an [FFI](http://luajit.org/ext_ffi.html) API to support the [ngx.pipe](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/pipe.md#readme) API provided by [lua-resty-core](https://github.com/openresty/lua-resty-core#readme). _Thanks OpenResty Inc. for supporting this work and spacewander for the development of the patch._
+    * feature: added an [FFI](http://luajit.org/ext_ffi.html) API for retrieving `env` directives values from [init_by_lua*](https://github.com/openresty/lua-nginx-module#init_by_lua). _Thanks Thibault Charbonnier for the patch._
+    * change: we no longer support the standard Lua 5.1 interpreter (PUC-Rio Lua). It is now strongly recommended to use the OpenResty LuaJIT releases, bundled with the official OpenResty releases.
+    * change: we now avoid running [init_by_lua*](https://github.com/openresty/lua-nginx-module#init_by_lua) in signaller processes and when testing the [nginx](nginx.html) configuration. _Thanks spacewander for the patch._
+    * change: we now print an alert when a non openresty-specific version of LuaJIT is detected since many optimizations would be missing. _Thanks Thibault Charbonnier for the patch._
+    * change: we now print a warning when writing to the Lua global variable `_G`.
+    * change: we now avoid generating the Content-Type response header when getting all response headers. _Thanks spacewander for the patch._
+    * bugfix: fixed a segfault in [nginx](nginx.html) core >= 1.15.0 when [init_worker_by_lua*](https://github.com/openresty/lua-nginx-module#init_worker_by_lua) is used. _Thanks Datong Sun for the patch._
+    * bugfix: [ngx.process](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/process.md#readme): [type()](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/process.md#type) didn't return 'master' in master process. _Thanks spacewander for the patch._
+    * bugfix: [tcpsock:setkeepalive()](https://github.com/openresty/lua-nginx-module#tcpsocksetkeepalive): worker processes might take too long to gracefully shutdown when the keep alive connections take a long max idle time. _Thanks Dejiang Zhu for the patch._
+    * bugfix: setting the request "Host" header should clear any existing cached `$host` variable so that subsequent reads return the expected result.
+    * bugfix: inlined Lua code snippets in `nginx.conf` failed to use the Lua source checksum as part of the Lua code cache key.
+    * bugfix: silenced `-Wcast-function-type` warnings, allowing for compilation with gcc8. _Thanks Alessandro Ghedini for the patch._
+    * doc: noted that [ngx.req.get_method()](https://github.com/openresty/lua-nginx-module#ngxreqget_method) can be used in the [body_filter_by_lua*](https://github.com/openresty/lua-nginx-module#body_filter_by_lua) and [log_by_lua*](https://github.com/openresty/lua-nginx-module#log_by_lua) phases. _Thanks tokers for the patch._
+    * doc: updated the docs to reflect the change that we now no longer support the standard Lua 5.1 interpreter in this module. also recommended OpenResty's LuaJIT branch version instead of the stock LuaJIT.
+    * doc: mention that [ngx.req.set_body_data()](https://github.com/openresty/lua-nginx-module#ngxreqset_body_data) and [ngx.req.set_body_file()](https://github.com/openresty/lua-nginx-module#ngxreqset_body_file) must read the request body. _Thanks Thibault Charbonnier for the patch._
+    * doc: fixed the links to [ssl_session_store_by_lua*](https://github.com/openresty/lua-nginx-module#ssl_session_store_by_lua_block). _Thanks chronolaw for the patch._
+    * typo: fixed a debug log in access and rewrite handlers. _Thanks sbhr for the patch._
+* upgraded [ngx_stream_lua](https://github.com/openresty/stream-lua-nginx-module#readme) to 0.0.6.
+    * feature: added support for ARM64. _Thanks Cloudflare for sponsoring this work. Thanks Dejiang Zhu and Zexuan Luo for the development of the patch._
+    * feature: implemented the preread [reqsock:peek()](https://github.com/openresty/stream-lua-nginx-module#reqsockpeek) API. _Thanks Kong Inc. for sponsoring this work. Thanks Datong Sun for the development of the patch._
+    * feature: enabled [ssl_certificate_by_lua*](https://github.com/openresty/lua-nginx-module#ssl_certificate_by_lua_block) support. _Thanks Kong Inc. for sponsoring the development of this feature, and thanks James Callahan and Datong Sun for the development of the patch._
+    * feature: implemented a new [lua_sa_restart](https://github.com/openresty/lua-nginx-module#lua_sa_restart) directive, which sets the `SA_RESTART` flag on [nginx](nginx.html) workers signal dispositions. _Thanks Thibault Charbonnier for the patch._
+    * feature: enabled resty.core.shdict support. _Thanks Datong Sun for the patch._
+    * feature: enabled [ngx.semaphore](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/semaphore.md#readme) support. _Thanks Datong Sun for the patch._
+    * feature: enabled [ngx.errlog](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/errlog.md#readme) support. _Thanks Thibault Charbonnier for the patch._
+    * feature: added an [FFI](http://luajit.org/ext_ffi.html) API for retrieving `env` directives values from [init_by_lua*](https://github.com/openresty/lua-nginx-module#init_by_lua). _Thanks Thibault Charbonnier for the patch._
+    * change: we now avoid running [init_by_lua*](https://github.com/openresty/lua-nginx-module#init_by_lua) in signaller processes and when testing the [nginx](nginx.html) configuration. _Thanks Thibault Charbonnier for the patch._
+    * change: we now print an alert when a non openresty-specific version of LuaJIT is detected since many optimizations would be missing. _Thanks Thibault Charbonnier for the patch._
+    * misc: re-rendered all files to include newly added template header. _Thanks Datong Sun for the patch._
+    * doc: added missing links for [ssl_certificate_by_lua*](https://github.com/openresty/lua-nginx-module#ssl_certificate_by_lua_block) directives. _Thanks chronolaw for the patch._
+* upgraded [lua-resty-core](https://github.com/openresty/lua-resty-core#readme) to 0.1.16.
+    * feature: added support for ARM64 (AArch64). _Thanks Cloudflare for sponsoring this work. Thanks Dejiang Zhu and Zexuan Luo for the development of the patch._
+    * feature: implemented the [ngx.pipe](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/pipe.md#readme) API which allows spawning processes and communicating with them in a non-blocking way. _Thanks OpenResty Inc. for supporting this work and spacewander for the development of the patch._
+    * feature: [ssl_certificate_by_lua*](https://github.com/openresty/lua-nginx-module#ssl_certificate_by_lua_block) support for the stream subsystem. _Thanks Kong Inc. for sponsoring the development of this feature, and thanks James Callahan and Datong Sun for the development of the patch._
+    * feature: resty.core.shdict: enabled the FFI-based API for the stream subsystem. _Thanks Datong Sun for the patch._
+    * feature: [ngx.semaphore](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/semaphore.md#readme): enabled the FFI-based API for the stream subsystem. _Thanks Datong Sun for the patch._
+    * feature: [ngx.errlog](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/errlog.md#readme): enabled the FFI-based API for the stream subsystem. _Thanks Thibault Charbonnier for the patch._
+    * feature: `os.getenv` is now able to retrieve `env` directives values from within [init_by_lua*](https://github.com/openresty/lua-nginx-module#init_by_lua). _Thanks Thibault Charbonnier for the patch._
+    * change: we now require OpenResty's LuaJIT branch to work properly on ARM64 since we make use of the `thread.exdata` Lua API.
+    * change: increased stack level on subsystem violation error to expose the offending module. _Thanks Datong Sun for the patch._
+    * feature: implemented the `ndk.*` API with [FFI](http://luajit.org/ext_ffi.html).
+    * bugfix: [ngx.process](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/process.md#readme): [type()](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/process.md#type) didn't return 'master' in master process. _Thanks spacewander for the patch._
+    * bugfix: now we only allow a single version of [ngx_lua](https://github.com/openresty/lua-nginx-module#readme) and [ngx_stream_lua](https://github.com/openresty/stream-lua-nginx-module#readme). _Thanks spacewander for the patch._
+    * optimize: fixed misuses of Lua global variables in our Lua code (caught by the new version of the lj-releng tool).
+    * doc: [ngx.process](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/process.md#readme): fixed a typo in the spelling of 'privileged agent'. _Thanks spacewander for the patch._
+    * doc: [ngx.process](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/process.md#readme): updated the process type list. _Thanks spacewander for the patch._
+    * doc: [ngx.balancer](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/balancer.md#readme): fixed a typo in the sample code. _Thanks chronolaw for the patch._
+    * doc: [ngx.ssl](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/ssl.md#readme): documented the `get_tls1_version_str()` API function.
+    * doc: [ngx.semaphore](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/semaphore.md#readme): switch status to production ready.
+* upgraded LuaJIT to 2.1-20190228: https://github.com/openresty/luajit2/tags
+    * feature: implemented a new [table.isempty()](https://github.com/openresty/luajit2/blob/v2.1-agentzh/README) API. _Thanks OpenResty Inc. for supporting this work._
+    * feature: implemented a new [table.isarray()](https://github.com/openresty/luajit2/blob/v2.1-agentzh/README) API. _Thanks OpenResty Inc. for supporting this work._
+    * feature: implemented a new [table.nkeys()](https://github.com/openresty/luajit2/blob/v2.1-agentzh/README) API. _Thanks OpenResty Inc. for supporting this work._
+    * feature: implemented the new Lua and C API functions for [thread.exdata](https://github.com/openresty/luajit2/blob/v2.1-agentzh/README). This API is used internally by the OpenResty and we advise not to use it yourself in the context of OpenResty. _Thanks Zexuan Luo for preparing the final version of the patch._
+    * feature: luajit.h: defined the macro `OPENRESTY_LUAJIT` for our branch of LuaJIT.
+    * change: run the LJ_64 branch in asm_hrefk when LUAJIT_USE_VALGRIND and LUAJIT_ENABLE_GC64 are both supplied. _Thanks spacewander for the patch._
+    * bugfix: `ffi.C.FUNC()`: it lacked a write barrier which might lead to use-after-free issues and memory corruptions.
+    * bugfix: LuaJIT's `jit.v` module might lead to segfaults due to buggy Lua stack traversal code.
+    * bugfix: 16-bit MCLink.mapofs and GCtrace.nsnapmap fields would overflow for large Lua programs, leading to segfaults; enlarged them to 32-bit.
+    * bugfix: fixed assertion failure "lj_record.c:92: rec_check_slots: Assertion `nslots <= 250' failed" found by stressing our edgelang compiler.
+    * doc: documented what we change in our OpenResty branch of LuaJIT.
+    * imported Mike Pall's latest changes:
+        * Improve luaL_addlstring().
+        * Fix os.date() for wider libc strftime() compatibility.
+        * Fix MinGW build.
+        * DynASM/MIPS: Fix shadowed variable.
+        * DynASM/PPC: Fix shadowed variable.
+        * Fix overflow of snapshot map offset.
+        * Better detection of MinGW build.
+        * Actually implement maxirconst trace limit.
+        * MIPS/MIPS64: Fix TSETR barrier (again).
+        * Fix memory probing allocator to check for valid end address, too.
+        * DynASM/x86: Fix vroundps/vroundpd encoding.
+        * DynASM: Fix warning.
+        * ARM64: Fix exit stub patching.
+        * ARM64: Fix write barrier in BC_USETS.
+        * Windows: Add UWP support, part 1.
+        * From Lua 5.3: assert() accepts any type of error object.
+        * x86: Disassemble FMA3 instructions.
+        * DynASM/x86: Add FMA3 instructions.
+        * PPC/NetBSD: Fix endianess check.
+        * x86/x64: Check for jcc when using xor r,r in emit_loadi().
+        * [FFI](http://luajit.org/ext_ffi.html): Make FP to U64 conversions match JIT backend behavior.
+        * Bump copyright date to 2018.
+        * [FFI](http://luajit.org/ext_ffi.html): Add tonumber() specialization for failed conversions.
+        * Give expected results for negative non-base-10 numbers in tonumber().
+* upgraded [lua-resty-lrucache](https://github.com/openresty/lua-resty-lrucache#readme) to 0.09.
+    * optimize: fixed misuses of Lua global variables in our Lua code (caught by the new version of the lj-releng tool).
+* upgraded [lua-resty-lock](https://github.com/openresty/lua-resty-lock#readme) to 0.08.
+    * bugfix: we now enforce the use of lua-resty-core's resty.core.shdict module to avoid dead locking with the CFunction-based shdict API in [ngx_lua](https://github.com/openresty/lua-nginx-module#readme).
+    * doc: made it clearer that we depend on [lua-resty-core](https://github.com/openresty/lua-resty-core#readme).
+    * doc: documented the limitations of certain [ngx_lua](https://github.com/openresty/lua-nginx-module#readme) execution contexts which prohibit yielding.
+* upgraded [lua-resty-limit-traffic](https://github.com/openresty/lua-resty-limit-traffic#readme) to 0.06.
+    * bugfix: set_conn() method did not work at all due to a copy&paste error. _Thanks pearzl for the patch._
+    * doc: added the [resty.limit.count](https://github.com/openresty/lua-resty-limit-traffic/blob/master/lib/resty/limit/count.md#readme) module to the library's README. _Thanks Thibault Charbonnier for the patch._
+* upgraded [resty-cli](https://github.com/openresty/resty-cli#readme) to 0.23.
+    * feature: implemented new `--stap` and `--stap-opts` command-line options to trace the underlying [nginx](nginx.html) C process directly (without going through the Perl wrapper layer).
+    * feature: implemented a new `--main-conf` command-line option for specifying nginx's main {} context directives directly from the command line. _Thanks Datong Sun for the patch._
+    * feature: implemented a new `--gdb-opts` command-line option which implies `--gdb`. The `--valgrind-opts` option also implies `--valgrind`.
+    * bugfix: md2pod: infinite looping might happen when an empty `.md` file is given.
+* upgraded [lua-resty-upstream-healthcheck](https://github.com/openresty/lua-resty-upstream-healthcheck#readme) to 0.06.
+    * bugfix: avoided shadowing a variable which would prevent the checking threads from being waited upon. _Thanks Thijs Schreijer and Thibault Charbonnier for the report and fix._
+
+Feedback welcome!
+
+Thanks!

--- a/v2/en/ann-1015008001rc1.md.tt2
+++ b/v2/en/ann-1015008001rc1.md.tt2
@@ -1,0 +1,196 @@
+[% VER = "1.15.8.1"; RC = 1 -%]
+<!---
+    @title         OpenResty [% VER %] RC[% RC %] is out
+--->
+
+We have just kicked out a new release candidate, OpenResty [% VER %] RC[% RC %],
+for the community to test out:
+
+https://openresty.org/download/openresty-[% VER %]rc[% RC %].tar.gz
+
+PGP for this source tar ball:
+
+https://openresty.org/download/openresty-[% VER %]rc[% RC %].tar.gz.asc
+
+Win64 version:
+
+https://openresty.org/download/openresty-[% VER %]rc[% RC %]-win64.zip
+
+PGP for the Win64 zip file:
+
+https://openresty.org/download/openresty-[% VER %]rc[% RC %]-win64.zip.asc
+
+Win32 version:
+
+https://openresty.org/download/openresty-[% VER %]rc[% RC %]-win32.zip
+
+PGP for the Win32 zip file:
+
+https://openresty.org/download/openresty-[% VER %]rc[% RC %]-win32.zip.asc
+
+Special thanks go to all our developers and contributors! Also thanks Thibault Charbonnier
+for his great help in preparing this release.
+
+The highlights of this release are:
+
+1. Based on the very recent mainline [nginx](nginx.html) core 1.15.8.
+2. Support for ARM64 architectures. The underlying work for this feature
+allowed to speed up other architectures by up to ~10%.
+3. New lua-resty-shell library for efficiently spawning sub-processes via the
+new ngx.pipe API.
+4. New lua-resty-signal library for killing and sending signals to UNIX
+processes.
+5. New lua-tablepool library for efficiently recycling Lua tables.
+6. We dropped support for the standard Lua 5.1 interpreter, and vividly
+recommend the use of OpenResty's fork of LuaJIT.
+7. [ngx_lua](https://github.com/openresty/lua-nginx-module#readme)
+    * New ngx.pipe API which allows spawning sub-processes and communicating
+    with them in a non-blocking way.
+    * Support for connections backlog queuing in cosockets via the new pool_size
+    and backlog options of the [tcpsock:connect()](https://github.com/openresty/lua-nginx-module#tcpsockconnect) method.
+    * New tcpsock:receiveany() API for BSD-style receive.
+8. [ngx_stream_lua](https://github.com/openresty/stream-lua-nginx-module#readme) module
+    * New reqsock:peek() API for the [ngx_stream_lua](https://github.com/openresty/stream-lua-nginx-module#readme) module, to peek into the
+    preread buffer without consuming the data.
+    * We enabled support for [ssl_certificate_by_lua*](https://github.com/openresty/lua-nginx-module#ssl_certificate_by_lua_block) in the [ngx_stream_lua](https://github.com/openresty/stream-lua-nginx-module#readme)
+    module.
+    * We enabled support for the FFI-based shdict API, [ngx.semaphore](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/semaphore.md#readme), and
+    [ngx.errlog](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/errlog.md#readme).
+9. LuaJIT
+    * We now enable the GC64 mode of LuaJIT by default on x86_64
+    platforms.
+    * Implemented a new [table.isempty()](https://github.com/openresty/luajit2#tableisempty) API.
+    * Implemented a new [table.isarray()](https://github.com/openresty/luajit2#tableisarray) API.
+    * Implemented a new [table.nkeys()](https://github.com/openresty/luajit2#tablenkeys) API.
+
+    All our new Lua API functions documentation can be found here: https://github.com/openresty/luajit2#new-api
+
+Complete change logs since the last (formal) release, 1.13.6.2:
+
+* upgraded the [nginx](nginx.html) core to 1.15.8.
+    * see the changes here: http://nginx.org/en/CHANGES
+* change: we now enable the GC64 mode by default in our bundled LuaJIT build for x86_64 architectures; this can be disabled using `--without-luajit-gc64`. _Thanks Thibault Charbonnier for the patch._
+* feature: bundled the [lua-tablepool](https://github.com/openresty/lua-tablepool#readme) library.
+* feature: bundled the [lua-resty-signal](https://github.com/openresty/lua-resty-signal#readme) library. _Thanks OpenResty Inc. for supporting this work._
+* feature: bundled the [lua-resty-shell](https://github.com/openresty/lua-resty-shell#readme) library. _Thanks OpenResty Inc. for supporting this work._
+* feature: ./configure: added new options `--without-stream_ssl_module` and `--without-stream`.
+* feature: ./configure: added support for the `-h` option.
+* feature: ./configure: support `@rpath` placeholder in OS X. _Thanks Datong Sun for the patch._
+* feature: updated the `socket_cloexec` patches to support the [ngx.pipe](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/pipe.md#readme) API. _Thanks OpenResty Inc. for supporting this work and spacewander for the development of the patch._
+* win32: upgraded openssl to 1.1.0j.
+* bugfix: [nginx](nginx.html) did not destroy the cycle memory pool before the daemon process exits. _Thanks Yuansheng Wang for the patch._
+* resty-doc indexes: skipped nginx's njs docs due to the use of special xml tags.
+* upgraded [ngx_lua](https://github.com/openresty/lua-nginx-module#readme) to 0.10.14.
+    * feature: added support for ARM64 (Aarch64). _Thanks Cloudflare for sponsoring this work. Thanks Dejiang Zhu and Zexuan Luo for the development of the patch._
+    * feature: added the `pool_size` and `backlog` options to the [tcpsock:connect()](https://github.com/openresty/lua-nginx-module#tcpsockconnect) API in order to support backlog queuing in cosocket connection pools. _Thanks OpenResty Inc. for supporting this work and spacewander for the development of the patch._
+    * feature: implemented a new [lua_sa_restart](https://github.com/openresty/lua-nginx-module#lua_sa_restart) directive, which sets the `SA_RESTART` flag on [nginx](nginx.html) workers signal dispositions. _Thanks Thibault Charbonnier for the patch._
+    * feature: implemented the [tcpsock:receiveany()](https://github.com/openresty/lua-nginx-module#tcpsockreceiveany) upstream cosocket API. _Thanks spacewander for the patch._
+    * feature: added support for the [nginx](nginx.html) builtin Link header, which allows for specifying multiple values for this header. _Thanks tokers and Thibault Charbonnier for the patch._
+    * feature: errors are now logged when timers fail to run. _Thanks spacewander for the patch._
+    * feature: added an [FFI](http://luajit.org/ext_ffi.html) API to support the [ngx.pipe](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/pipe.md#readme) API provided by [lua-resty-core](https://github.com/openresty/lua-resty-core#readme). _Thanks OpenResty Inc. for supporting this work and spacewander for the development of the patch._
+    * feature: added an [FFI](http://luajit.org/ext_ffi.html) API for retrieving `env` directives values from [init_by_lua*](https://github.com/openresty/lua-nginx-module#init_by_lua). _Thanks Thibault Charbonnier for the patch._
+    * change: we no longer support the standard Lua 5.1 interpreter (PUC-Rio Lua). It is now strongly recommended to use the OpenResty LuaJIT releases, bundled with the official OpenResty releases.
+    * change: we now avoid running [init_by_lua*](https://github.com/openresty/lua-nginx-module#init_by_lua) in signaller processes and when testing the [nginx](nginx.html) configuration. _Thanks spacewander for the patch._
+    * change: we now print an alert when a non openresty-specific version of LuaJIT is detected since many optimizations would be missing. _Thanks Thibault Charbonnier for the patch._
+    * change: we now print a warning when writing to the Lua global variable `_G`.
+    * change: we now avoid generating the Content-Type response header when getting all response headers. _Thanks spacewander for the patch._
+    * bugfix: fixed a segfault in [nginx](nginx.html) core >= 1.15.0 when [init_worker_by_lua*](https://github.com/openresty/lua-nginx-module#init_worker_by_lua) is used. _Thanks Datong Sun for the patch._
+    * bugfix: [ngx.process](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/process.md#readme): [type()](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/process.md#type) didn't return 'master' in master process. _Thanks spacewander for the patch._
+    * bugfix: [tcpsock:setkeepalive()](https://github.com/openresty/lua-nginx-module#tcpsocksetkeepalive): worker processes might take too long to gracefully shutdown when the keep alive connections take a long max idle time. _Thanks Dejiang Zhu for the patch._
+    * bugfix: setting the request "Host" header should clear any existing cached `$host` variable so that subsequent reads return the expected result.
+    * bugfix: inlined Lua code snippets in `nginx.conf` failed to use the Lua source checksum as part of the Lua code cache key.
+    * bugfix: silenced `-Wcast-function-type` warnings, allowing for compilation with gcc8. _Thanks Alessandro Ghedini for the patch._
+    * doc: noted that [ngx.req.get_method()](https://github.com/openresty/lua-nginx-module#ngxreqget_method) can be used in the [body_filter_by_lua*](https://github.com/openresty/lua-nginx-module#body_filter_by_lua) and [log_by_lua*](https://github.com/openresty/lua-nginx-module#log_by_lua) phases. _Thanks tokers for the patch._
+    * doc: updated the docs to reflect the change that we now no longer support the standard Lua 5.1 interpreter in this module. also recommended OpenResty's LuaJIT branch version instead of the stock LuaJIT.
+    * doc: mention that [ngx.req.set_body_data()](https://github.com/openresty/lua-nginx-module#ngxreqset_body_data) and [ngx.req.set_body_file()](https://github.com/openresty/lua-nginx-module#ngxreqset_body_file) must read the request body. _Thanks Thibault Charbonnier for the patch._
+    * doc: fixed the links to [ssl_session_store_by_lua*](https://github.com/openresty/lua-nginx-module#ssl_session_store_by_lua_block). _Thanks chronolaw for the patch._
+    * typo: fixed a debug log in access and rewrite handlers. _Thanks sbhr for the patch._
+* upgraded [ngx_stream_lua](https://github.com/openresty/stream-lua-nginx-module#readme) to 0.0.6.
+    * feature: added support for ARM64. _Thanks Cloudflare for sponsoring this work. Thanks Dejiang Zhu and Zexuan Luo for the development of the patch._
+    * feature: implemented the preread [reqsock:peek()](https://github.com/openresty/stream-lua-nginx-module#reqsockpeek) API. _Thanks Kong Inc. for sponsoring this work. Thanks Datong Sun for the development of the patch._
+    * feature: enabled [ssl_certificate_by_lua*](https://github.com/openresty/lua-nginx-module#ssl_certificate_by_lua_block) support. _Thanks Kong Inc. for sponsoring the development of this feature, and thanks James Callahan and Datong Sun for the development of the patch._
+    * feature: implemented a new [lua_sa_restart](https://github.com/openresty/lua-nginx-module#lua_sa_restart) directive, which sets the `SA_RESTART` flag on [nginx](nginx.html) workers signal dispositions. _Thanks Thibault Charbonnier for the patch._
+    * feature: enabled resty.core.shdict support. _Thanks Datong Sun for the patch._
+    * feature: enabled [ngx.semaphore](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/semaphore.md#readme) support. _Thanks Datong Sun for the patch._
+    * feature: enabled [ngx.errlog](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/errlog.md#readme) support. _Thanks Thibault Charbonnier for the patch._
+    * feature: added an [FFI](http://luajit.org/ext_ffi.html) API for retrieving `env` directives values from [init_by_lua*](https://github.com/openresty/lua-nginx-module#init_by_lua). _Thanks Thibault Charbonnier for the patch._
+    * change: we now avoid running [init_by_lua*](https://github.com/openresty/lua-nginx-module#init_by_lua) in signaller processes and when testing the [nginx](nginx.html) configuration. _Thanks Thibault Charbonnier for the patch._
+    * change: we now print an alert when a non openresty-specific version of LuaJIT is detected since many optimizations would be missing. _Thanks Thibault Charbonnier for the patch._
+    * misc: re-rendered all files to include newly added template header. _Thanks Datong Sun for the patch._
+    * doc: added missing links for [ssl_certificate_by_lua*](https://github.com/openresty/lua-nginx-module#ssl_certificate_by_lua_block) directives. _Thanks chronolaw for the patch._
+* upgraded [lua-resty-core](https://github.com/openresty/lua-resty-core#readme) to 0.1.16.
+    * feature: added support for ARM64 (AArch64). _Thanks Cloudflare for sponsoring this work. Thanks Dejiang Zhu and Zexuan Luo for the development of the patch._
+    * feature: implemented the [ngx.pipe](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/pipe.md#readme) API which allows spawning processes and communicating with them in a non-blocking way. _Thanks OpenResty Inc. for supporting this work and spacewander for the development of the patch._
+    * feature: [ssl_certificate_by_lua*](https://github.com/openresty/lua-nginx-module#ssl_certificate_by_lua_block) support for the stream subsystem. _Thanks Kong Inc. for sponsoring the development of this feature, and thanks James Callahan and Datong Sun for the development of the patch._
+    * feature: resty.core.shdict: enabled the FFI-based API for the stream subsystem. _Thanks Datong Sun for the patch._
+    * feature: [ngx.semaphore](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/semaphore.md#readme): enabled the FFI-based API for the stream subsystem. _Thanks Datong Sun for the patch._
+    * feature: [ngx.errlog](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/errlog.md#readme): enabled the FFI-based API for the stream subsystem. _Thanks Thibault Charbonnier for the patch._
+    * feature: `os.getenv` is now able to retrieve `env` directives values from within [init_by_lua*](https://github.com/openresty/lua-nginx-module#init_by_lua). _Thanks Thibault Charbonnier for the patch._
+    * change: we now require OpenResty's LuaJIT branch to work properly on ARM64 since we make use of the `thread.exdata` Lua API.
+    * change: increased stack level on subsystem violation error to expose the offending module. _Thanks Datong Sun for the patch._
+    * feature: implemented the `ndk.*` API with [FFI](http://luajit.org/ext_ffi.html).
+    * bugfix: [ngx.process](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/process.md#readme): [type()](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/process.md#type) didn't return 'master' in master process. _Thanks spacewander for the patch._
+    * bugfix: now we only allow a single version of [ngx_lua](https://github.com/openresty/lua-nginx-module#readme) and [ngx_stream_lua](https://github.com/openresty/stream-lua-nginx-module#readme). _Thanks spacewander for the patch._
+    * optimize: fixed misuses of Lua global variables in our Lua code (caught by the new version of the lj-releng tool).
+    * doc: [ngx.process](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/process.md#readme): fixed a typo in the spelling of 'privileged agent'. _Thanks spacewander for the patch._
+    * doc: [ngx.process](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/process.md#readme): updated the process type list. _Thanks spacewander for the patch._
+    * doc: [ngx.balancer](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/balancer.md#readme): fixed a typo in the sample code. _Thanks chronolaw for the patch._
+    * doc: [ngx.ssl](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/ssl.md#readme): documented the `get_tls1_version_str()` API function.
+    * doc: [ngx.semaphore](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/semaphore.md#readme): switch status to production ready.
+* upgraded LuaJIT to 2.1-20190228: https://github.com/openresty/luajit2/tags
+    * feature: implemented a new [table.isempty()](https://github.com/openresty/luajit2/blob/v2.1-agentzh/README) API. _Thanks OpenResty Inc. for supporting this work._
+    * feature: implemented a new [table.isarray()](https://github.com/openresty/luajit2/blob/v2.1-agentzh/README) API. _Thanks OpenResty Inc. for supporting this work._
+    * feature: implemented a new [table.nkeys()](https://github.com/openresty/luajit2/blob/v2.1-agentzh/README) API. _Thanks OpenResty Inc. for supporting this work._
+    * feature: implemented the new Lua and C API functions for [thread.exdata](https://github.com/openresty/luajit2/blob/v2.1-agentzh/README). This API is used internally by the OpenResty and we advise not to use it yourself in the context of OpenResty. _Thanks Zexuan Luo for preparing the final version of the patch._
+    * feature: luajit.h: defined the macro `OPENRESTY_LUAJIT` for our branch of LuaJIT.
+    * change: run the LJ_64 branch in asm_hrefk when LUAJIT_USE_VALGRIND and LUAJIT_ENABLE_GC64 are both supplied. _Thanks spacewander for the patch._
+    * bugfix: `ffi.C.FUNC()`: it lacked a write barrier which might lead to use-after-free issues and memory corruptions.
+    * bugfix: LuaJIT's `jit.v` module might lead to segfaults due to buggy Lua stack traversal code.
+    * bugfix: 16-bit MCLink.mapofs and GCtrace.nsnapmap fields would overflow for large Lua programs, leading to segfaults; enlarged them to 32-bit.
+    * bugfix: fixed assertion failure "lj_record.c:92: rec_check_slots: Assertion `nslots <= 250' failed" found by stressing our edgelang compiler.
+    * doc: documented what we change in our OpenResty branch of LuaJIT.
+    * imported Mike Pall's latest changes:
+        * Improve luaL_addlstring().
+        * Fix os.date() for wider libc strftime() compatibility.
+        * Fix MinGW build.
+        * DynASM/MIPS: Fix shadowed variable.
+        * DynASM/PPC: Fix shadowed variable.
+        * Fix overflow of snapshot map offset.
+        * Better detection of MinGW build.
+        * Actually implement maxirconst trace limit.
+        * MIPS/MIPS64: Fix TSETR barrier (again).
+        * Fix memory probing allocator to check for valid end address, too.
+        * DynASM/x86: Fix vroundps/vroundpd encoding.
+        * DynASM: Fix warning.
+        * ARM64: Fix exit stub patching.
+        * ARM64: Fix write barrier in BC_USETS.
+        * Windows: Add UWP support, part 1.
+        * From Lua 5.3: assert() accepts any type of error object.
+        * x86: Disassemble FMA3 instructions.
+        * DynASM/x86: Add FMA3 instructions.
+        * PPC/NetBSD: Fix endianess check.
+        * x86/x64: Check for jcc when using xor r,r in emit_loadi().
+        * [FFI](http://luajit.org/ext_ffi.html): Make FP to U64 conversions match JIT backend behavior.
+        * Bump copyright date to 2018.
+        * [FFI](http://luajit.org/ext_ffi.html): Add tonumber() specialization for failed conversions.
+        * Give expected results for negative non-base-10 numbers in tonumber().
+* upgraded [lua-resty-lrucache](https://github.com/openresty/lua-resty-lrucache#readme) to 0.09.
+    * optimize: fixed misuses of Lua global variables in our Lua code (caught by the new version of the lj-releng tool).
+* upgraded [lua-resty-lock](https://github.com/openresty/lua-resty-lock#readme) to 0.08.
+    * bugfix: we now enforce the use of lua-resty-core's resty.core.shdict module to avoid dead locking with the CFunction-based shdict API in [ngx_lua](https://github.com/openresty/lua-nginx-module#readme).
+    * doc: made it clearer that we depend on [lua-resty-core](https://github.com/openresty/lua-resty-core#readme).
+    * doc: documented the limitations of certain [ngx_lua](https://github.com/openresty/lua-nginx-module#readme) execution contexts which prohibit yielding.
+* upgraded [lua-resty-limit-traffic](https://github.com/openresty/lua-resty-limit-traffic#readme) to 0.06.
+    * bugfix: set_conn() method did not work at all due to a copy&paste error. _Thanks pearzl for the patch._
+    * doc: added the [resty.limit.count](https://github.com/openresty/lua-resty-limit-traffic/blob/master/lib/resty/limit/count.md#readme) module to the library's README. _Thanks Thibault Charbonnier for the patch._
+* upgraded [resty-cli](https://github.com/openresty/resty-cli#readme) to 0.23.
+    * feature: implemented new `--stap` and `--stap-opts` command-line options to trace the underlying [nginx](nginx.html) C process directly (without going through the Perl wrapper layer).
+    * feature: implemented a new `--main-conf` command-line option for specifying nginx's main {} context directives directly from the command line. _Thanks Datong Sun for the patch._
+    * feature: implemented a new `--gdb-opts` command-line option which implies `--gdb`. The `--valgrind-opts` option also implies `--valgrind`.
+    * bugfix: md2pod: infinite looping might happen when an empty `.md` file is given.
+* upgraded [lua-resty-upstream-healthcheck](https://github.com/openresty/lua-resty-upstream-healthcheck#readme) to 0.06.
+    * bugfix: avoided shadowing a variable which would prevent the checking threads from being waited upon. _Thanks Thijs Schreijer and Thibault Charbonnier for the report and fix._
+
+Feedback welcome!
+
+Thanks!

--- a/v2/en/openresty.md
+++ b/v2/en/openresty.md
@@ -4,6 +4,8 @@
     @created       2011-06-21 04:03 GMT
 --->
 
+***New!*** [OpenResty 1.15.8.1 RC1](ann-1015008001rc1.html) is now available for testing.
+
 OpenResty<sup>&reg;</sup> is a full-fledged web platform that integrates the standard
 [Nginx](nginx.html) core, [LuaJIT](luajit.html), many carefully written Lua
 libraries, lots of high quality [3rd-party Nginx modules](components.html), and

--- a/v2/util/gen-ann-email
+++ b/v2/util/gen-ann-email
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+infile=$1
+name=$2
+
+if [ -z "$infile" ]; then
+    echo "No .md input file specified." > /dev/stderr
+    exit 1
+fi
+
+if [ ! -f "$infile" ]; then
+    echo "Input file $infile not found." > /dev/stderr
+    exit 1
+fi
+
+if [ -z "$name" ]; then
+    name=Yichun
+fi
+
+outfile=email.md
+printf "Hi folks!\n\n" > $outfile || exit 1
+cat $infile >> $outfile || exit 1
+printf "\nBest regards,\n$name\n" >> $outfile || exit 1
+
+exec md2pod.pl $outfile | pod2text -u -i 1 -w 69 --nourls -

--- a/v2/util/gen-plain-changes
+++ b/v2/util/gen-plain-changes
@@ -7,5 +7,5 @@ perl -ne 'exit if /^See \[ChangeLog \d/;
               next;
           }
           print;
-          ' $1 > /tmp/changes.txt || exit 1
-exec md2pod.pl /tmp/changes.txt | pod2text -u -i 1 -w 69 --nourls -
+          ' $1 > /tmp/changes.md || exit 1
+exec md2pod.pl /tmp/changes.md | pod2text -u -i 1 -w 69 --nourls -

--- a/v2/util/resolve-links.pl
+++ b/v2/util/resolve-links.pl
@@ -141,7 +141,7 @@ while (<$in>) {
             "$pre\[$txt](https://github.com/openresty/lua-resty-limit-traffic/blob/master/lib/$file.md#readme)$post"
             !egx;
 
-    $c += s! (\s) ( resty\.core\.shdict | ngx\.(?:re|process|errlog|semaphore|ssl(?:\.session)?|balancer|ocsp|resp|req) ) ( [\s,.:;?] ) !
+    $c += s! (\s) ( ngx\.(?:re|process|errlog|semaphore|ssl(?:\.session)?|balancer|ocsp|resp|req) ) ( [\s,.:;?] ) !
             my ($pre, $txt, $post) = ($1, $2, $3);
             (my $file = $txt) =~ s{\.}{/}g;
             "$pre\[$txt](https://github.com/openresty/lua-resty-core/blob/master/lib/$file.md#readme)$post"
@@ -151,6 +151,7 @@ while (<$in>) {
     $c += s! (\s) (error_log|proxy_pass|proxy_next_upstream_tries|error_page|client_body_buffer_size) ( [\s,.:;?] ) !$1\[$2](http://nginx.org/r/$2)$3!gxs;
 
     $c += s! (\s) (table\.concat|string\.find) ( (?:\(\))? ) ( [\s,.:;?] ) !$1\[$2$3](http://www.lua.org/manual/5.1/manual.html#pdf-$2)$4!gxs;
+    $c += s! (\s) (table)\.(isempty|isarray|nkeys|clone) ( (?:\(\))? ) ( [\s,.:;?] ) !$1\[$2.$3$4](https://github.com/openresty/luajit2#$2$3)$5!gxs;
     $c += s! (\s) ([Nn]ginx) ( [\s,.:;?] ) !$1\[$2](nginx.html)$3!gxsi;
     print $out $_;
 }

--- a/v2/util/test-links.pl
+++ b/v2/util/test-links.pl
@@ -1,0 +1,26 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+my $i = 0;
+
+sub test_link ($) {
+    my $link = shift;
+    my $out = `curl -I -sS '$link'`;
+    #print "$link\n";
+    #my $out = "HTTP/1.1 200 OK";
+    if ($out !~ m{\bHTTP/\d+(?:\.\d+)?\s+200\s+OK\b}) {
+        die "\nFailed to test link: $link\n$out";
+    } else {
+        $i++;
+        print STDERR "$i OK\r";
+    }
+}
+
+while (<>) {
+    while (m{ \b ( https?:// [^\)\s\]]+ ) }xmg) {
+        test_link $1;
+    }
+}
+print "\n";


### PR DESCRIPTION
also added new tool util/test-links.pl to test links in the specified .md input file (or any other files).

util/resolve-links.pl: removed the broken link for resty.core.shdict.
also added links for our own table.* API functions in our LuaJIT.