### PR TITLE
getting-started: changed the depracated `content_by_lua` example to u…

### DIFF
--- a/v2/cn/getting-started.md
+++ b/v2/cn/getting-started.md
@@ -43,9 +43,9 @@ http {
         listen 8080;
         location / {
             default_type text/html;
-            content_by_lua '
+            content_by_lua_block {
                 ngx.say("<p>hello, world</p>")
-            ';
+            }
         }
     }
 }

--- a/v2/en/getting-started.md
+++ b/v2/en/getting-started.md
@@ -74,9 +74,9 @@ http {
         listen 8080;
         location / {
             default_type text/html;
-            content_by_lua '
+            content_by_lua_block {
                 ngx.say("<p>hello, world</p>")
-            ';
+            }
         }
     }
 }


### PR DESCRIPTION
…se now recommended `content_by_lua_block`.