### PR TITLE
Update installation.md

### DIFF
--- a/v2/en/installation.md
+++ b/v2/en/installation.md
@@ -106,7 +106,7 @@ apt-get install libpcre3-dev \
 You're recommended to install the following packages using yum:
 
 ```bash
-yum install pcre-devel openssl-devel gcc curl
+yum install pcre-devel openssl-devel gcc curl zlib-devel
 ```
 
 ### Mac OS X (macOS) users


### PR DESCRIPTION
default installation need zlib-devel

checking for zlib library ... not found

./configure: error: the HTTP gzip module requires the zlib library. You can either disable the module by using --without-http_gzip_module option, or install the zlib library into the system, or build the zlib library statically from the source with nginx by using --with-zlib=<path> option.