### PR TITLE
Update installation.md

### DIFF
--- a/v2/cn/installation.md
+++ b/v2/cn/installation.md
@@ -55,7 +55,7 @@ apt-get install libpcre3-dev \
 推荐您使用yum安装以下的开发库:
 
 ```bash
-yum install pcre-devel openssl-devel gcc curl
+yum install pcre-devel openssl-devel gcc curl zlib-devel
 ```
 
 ## Mac OS X (macOS) 用户


### PR DESCRIPTION
default installation need zlib-devel

checking for zlib library ... not found

./configure: error: the HTTP gzip module requires the zlib library. You can either disable the module by using --without-http_gzip_module option, or install the zlib library into the system, or build the zlib library statically from the source with nginx by using --with-zlib=<path> option.