### PR TITLE
change: clarified that the risk of CVE-2024-39702 originates from the…

### DIFF
--- a/v2/cn/ann-1019009002.md.tt2
+++ b/v2/cn/ann-1019009002.md.tt2
@@ -4,9 +4,12 @@
 --->
 
 OpenResty [% version %] is a security update addressing a performance issue in
-LuaJIT related to hash computation optimization. This update disables a
+our OpenResty branch of LuaJIT related to hash computation optimization.
+We sincerely apologize for any confusion and want to clarify that this issue
+originates from our branch, not from upstream LuaJIT. This update disables a
 specific optimization in LuaJIT that could potentially lead to severe
 performance degradation under certain circumstances ([CVE-2024-39702](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-39702)).
+We would like to express our gratitude to Kong Inc. for reporting this issue.
 
 [Download this version here](download.html).
 
@@ -19,7 +22,8 @@ This is the second OpenResty release based on the nginx [% major_ver %] core.
 
 # Version highlights
 
-* Applied a patch to LuaJIT addressing performance issues related to hash computation optimization.
+* Applied a patch to our OpenResty branch of LuaJIT addressing performance
+issues related to hash computation optimization.
 
 # Full Change logs
 

--- a/v2/cn/ann-1019009002.md.tt2
+++ b/v2/cn/ann-1019009002.md.tt2
@@ -9,7 +9,7 @@ We sincerely apologize for any confusion and want to clarify that this issue
 originates from our branch, not from upstream LuaJIT. This update disables a
 specific optimization in LuaJIT that could potentially lead to severe
 performance degradation under certain circumstances ([CVE-2024-39702](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-39702)).
-We would like to express our gratitude to Kong Inc. for reporting this issue.
+We would like to express our gratitude to Zhongwei Yao from Kong Inc. for reporting this issue.
 
 [Download this version here](download.html).
 

--- a/v2/cn/ann-1021004004.md.tt2
+++ b/v2/cn/ann-1021004004.md.tt2
@@ -4,9 +4,12 @@
 --->
 
 OpenResty [% version %] is a security update addressing a performance issue in
-LuaJIT related to hash computation optimization. This update disables a
+our OpenResty branch of LuaJIT related to hash computation optimization.
+We sincerely apologize for any confusion and want to clarify that this issue
+originates from our branch, not from upstream LuaJIT. This update disables a
 specific optimization in LuaJIT that could potentially lead to severe
 performance degradation under certain circumstances ([CVE-2024-39702](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-39702)).
+We would like to express our gratitude to Kong Inc. for reporting this issue.
 
 [Download this version here](download.html).
 
@@ -19,7 +22,8 @@ This is the fourth OpenResty release based on the nginx [% major_ver %] core.
 
 # Version highlights
 
-* Applied a patch to LuaJIT addressing performance issues related to hash computation optimization.
+* Applied a patch to our OpenResty branch of LuaJIT addressing performance
+issues related to hash computation optimization.
 
 # Full Change logs
 

--- a/v2/cn/ann-1021004004.md.tt2
+++ b/v2/cn/ann-1021004004.md.tt2
@@ -9,7 +9,7 @@ We sincerely apologize for any confusion and want to clarify that this issue
 originates from our branch, not from upstream LuaJIT. This update disables a
 specific optimization in LuaJIT that could potentially lead to severe
 performance degradation under certain circumstances ([CVE-2024-39702](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-39702)).
-We would like to express our gratitude to Kong Inc. for reporting this issue.
+We would like to express our gratitude to Zhongwei Yao from Kong Inc. for reporting this issue.
 
 [Download this version here](download.html).
 

--- a/v2/cn/ann-1025003002.md.tt2
+++ b/v2/cn/ann-1025003002.md.tt2
@@ -4,9 +4,12 @@
 --->
 
 OpenResty [% version %] is a security update addressing a performance issue in
-LuaJIT related to hash computation optimization. This update disables a
+our OpenResty branch of LuaJIT related to hash computation optimization.
+We sincerely apologize for any confusion and want to clarify that this issue
+originates from our branch, not from upstream LuaJIT. This update disables a
 specific optimization in LuaJIT that could potentially lead to severe
 performance degradation under certain circumstances ([CVE-2024-39702](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-39702)).
+We would like to express our gratitude to Kong Inc. for reporting this issue.
 
 [Download this version here](download.html).
 
@@ -19,7 +22,8 @@ This is the second OpenResty release based on the nginx [% major_ver %] core.
 
 # Version highlights
 
-* Applied a patch to LuaJIT addressing performance issues related to hash computation optimization.
+* Applied a patch to our OpenResty branch of LuaJIT addressing performance
+issues related to hash computation optimization.
 
 # Full Change logs
 

--- a/v2/cn/ann-1025003002.md.tt2
+++ b/v2/cn/ann-1025003002.md.tt2
@@ -9,7 +9,7 @@ We sincerely apologize for any confusion and want to clarify that this issue
 originates from our branch, not from upstream LuaJIT. This update disables a
 specific optimization in LuaJIT that could potentially lead to severe
 performance degradation under certain circumstances ([CVE-2024-39702](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-39702)).
-We would like to express our gratitude to Kong Inc. for reporting this issue.
+We would like to express our gratitude to Zhongwei Yao from Kong Inc. for reporting this issue.
 
 [Download this version here](download.html).
 

--- a/v2/cn/changelog-1019009.md
+++ b/v2/cn/changelog-1019009.md
@@ -7,7 +7,7 @@
 # Version 1.19.9.2 - 19 Jul 2024
 
 * upgraded [LuaJIT](https://github.com/openresty/luajit2) to 2.1-20210510.1.
-    * bugfix: disable hash computation optimization because of the possibility of severe degradation (CVE-2024-39702). This issue originates from the OpenResty LuaJIT branch. _Thanks Kong INC. for reporting the issue, and thanks lijunlong for the patch._
+    * bugfix: disable hash computation optimization because of the possibility of severe degradation (CVE-2024-39702). This issue originates from the OpenResty LuaJIT branch. _Thanks Zhongwei Yao from Kong INC. for reporting the issue, and thanks lijunlong for the patch._
 
 # Version 1.19.9.1 - 6 Aug 2021
 

--- a/v2/cn/changelog-1019009.md
+++ b/v2/cn/changelog-1019009.md
@@ -7,7 +7,7 @@
 # Version 1.19.9.2 - 19 Jul 2024
 
 * upgraded [LuaJIT](https://github.com/openresty/luajit2) to 2.1-20210510.1.
-    * bugfix: disable hash computation optimization because of the possibility of severe degradation (CVE-2024-39702). _Thanks lijunlong for the patch._
+    * bugfix: disable hash computation optimization because of the possibility of severe degradation (CVE-2024-39702). This issue originates from the OpenResty LuaJIT branch. _Thanks Kong INC. for reporting the issue, and thanks lijunlong for the patch._
 
 # Version 1.19.9.1 - 6 Aug 2021
 

--- a/v2/cn/changelog-1021004.md
+++ b/v2/cn/changelog-1021004.md
@@ -7,7 +7,7 @@
 # Version 1.21.4.4 - 19 Jul 2024
 
 * upgraded [LuaJIT](https://github.com/openresty/luajit2) to v2.1-20230410.1.
-    * bugfix: disable hash computation optimization because of the possibility of severe degradation (CVE-2024-39702). This issue originates from the OpenResty LuaJIT branch. _Thanks Kong INC. for reporting the issue, and thanks lijunlong for the patch._
+    * bugfix: disable hash computation optimization because of the possibility of severe degradation (CVE-2024-39702). This issue originates from the OpenResty LuaJIT branch. _Thanks Zhongwei Yao from Kong INC. for reporting the issue, and thanks lijunlong for the patch._
 
 # Version 1.21.4.3 - 7 Nov 2023
 

--- a/v2/cn/changelog-1021004.md
+++ b/v2/cn/changelog-1021004.md
@@ -7,7 +7,7 @@
 # Version 1.21.4.4 - 19 Jul 2024
 
 * upgraded [LuaJIT](https://github.com/openresty/luajit2) to v2.1-20230410.1.
-    * bugfix: disable hash computation optimization because of the possibility of severe degradation (CVE-2024-39702). _Thanks lijunlong for the patch._
+    * bugfix: disable hash computation optimization because of the possibility of severe degradation (CVE-2024-39702). This issue originates from the OpenResty LuaJIT branch. _Thanks Kong INC. for reporting the issue, and thanks lijunlong for the patch._
 
 # Version 1.21.4.3 - 7 Nov 2023
 

--- a/v2/cn/changelog-1025003.md
+++ b/v2/cn/changelog-1025003.md
@@ -7,7 +7,7 @@
 # Version 1.25.3.2 - 19 Jul 2024
 
 * upgraded [LuaJIT](https://github.com/openresty/luajit2) to v2.1-20231117.1
-    * bugfix: disable hash computation optimization because of the possibility of severe degradation (CVE-2024-39702). _Thanks lijunlong for the patch._
+    * bugfix: disable hash computation optimization because of the possibility of severe degradation (CVE-2024-39702). This issue originates from the OpenResty LuaJIT branch. _Thanks Kong INC. for reporting the issue, and thanks lijunlong for the patch._
 
 # Version 1.25.3.1 - 04 Jan 2024
 

--- a/v2/cn/changelog-1025003.md
+++ b/v2/cn/changelog-1025003.md
@@ -7,7 +7,7 @@
 # Version 1.25.3.2 - 19 Jul 2024
 
 * upgraded [LuaJIT](https://github.com/openresty/luajit2) to v2.1-20231117.1
-    * bugfix: disable hash computation optimization because of the possibility of severe degradation (CVE-2024-39702). This issue originates from the OpenResty LuaJIT branch. _Thanks Kong INC. for reporting the issue, and thanks lijunlong for the patch._
+    * bugfix: disable hash computation optimization because of the possibility of severe degradation (CVE-2024-39702). This issue originates from the OpenResty LuaJIT branch. _Thanks Zhongwei Yao from Kong INC. for reporting the issue, and thanks lijunlong for the patch._
 
 # Version 1.25.3.1 - 04 Jan 2024
 

--- a/v2/en/ann-1019009002.md.tt2
+++ b/v2/en/ann-1019009002.md.tt2
@@ -4,9 +4,12 @@
 --->
 
 OpenResty [% version %] is a security update addressing a performance issue in
-LuaJIT related to hash computation optimization. This update disables a
+our OpenResty branch of LuaJIT related to hash computation optimization.
+We sincerely apologize for any confusion and want to clarify that this issue
+originates from our branch, not from upstream LuaJIT. This update disables a
 specific optimization in LuaJIT that could potentially lead to severe
 performance degradation under certain circumstances ([CVE-2024-39702](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-39702)).
+We would like to express our gratitude to Kong Inc. for reporting this issue.
 
 [Download this version here](download.html).
 
@@ -19,7 +22,8 @@ This is the second OpenResty release based on the nginx [% major_ver %] core.
 
 # Version highlights
 
-* Applied a patch to LuaJIT addressing performance issues related to hash computation optimization.
+* Applied a patch to our OpenResty branch of LuaJIT addressing performance
+issues related to hash computation optimization.
 
 # Full Change logs
 

--- a/v2/en/ann-1019009002.md.tt2
+++ b/v2/en/ann-1019009002.md.tt2
@@ -9,7 +9,7 @@ We sincerely apologize for any confusion and want to clarify that this issue
 originates from our branch, not from upstream LuaJIT. This update disables a
 specific optimization in LuaJIT that could potentially lead to severe
 performance degradation under certain circumstances ([CVE-2024-39702](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-39702)).
-We would like to express our gratitude to Kong Inc. for reporting this issue.
+We would like to express our gratitude to Zhongwei Yao from Kong Inc. for reporting this issue.
 
 [Download this version here](download.html).
 

--- a/v2/en/ann-1021004004.md.tt2
+++ b/v2/en/ann-1021004004.md.tt2
@@ -4,9 +4,12 @@
 --->
 
 OpenResty [% version %] is a security update addressing a performance issue in
-LuaJIT related to hash computation optimization. This update disables a
+our OpenResty branch of LuaJIT related to hash computation optimization.
+We sincerely apologize for any confusion and want to clarify that this issue
+originates from our branch, not from upstream LuaJIT. This update disables a
 specific optimization in LuaJIT that could potentially lead to severe
 performance degradation under certain circumstances ([CVE-2024-39702](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-39702)).
+We would like to express our gratitude to Kong Inc. for reporting this issue.
 
 [Download this version here](download.html).
 
@@ -19,7 +22,8 @@ This is the fourth OpenResty release based on the nginx [% major_ver %] core.
 
 # Version highlights
 
-* Applied a patch to LuaJIT addressing performance issues related to hash computation optimization.
+* Applied a patch to our OpenResty branch of LuaJIT addressing performance
+issues related to hash computation optimization.
 
 # Full Change logs
 

--- a/v2/en/ann-1021004004.md.tt2
+++ b/v2/en/ann-1021004004.md.tt2
@@ -9,7 +9,7 @@ We sincerely apologize for any confusion and want to clarify that this issue
 originates from our branch, not from upstream LuaJIT. This update disables a
 specific optimization in LuaJIT that could potentially lead to severe
 performance degradation under certain circumstances ([CVE-2024-39702](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-39702)).
-We would like to express our gratitude to Kong Inc. for reporting this issue.
+We would like to express our gratitude to Zhongwei Yao from Kong Inc. for reporting this issue.
 
 [Download this version here](download.html).
 

--- a/v2/en/ann-1025003002.md.tt2
+++ b/v2/en/ann-1025003002.md.tt2
@@ -4,9 +4,12 @@
 --->
 
 OpenResty [% version %] is a security update addressing a performance issue in
-LuaJIT related to hash computation optimization. This update disables a
+our OpenResty branch of LuaJIT related to hash computation optimization.
+We sincerely apologize for any confusion and want to clarify that this issue
+originates from our branch, not from upstream LuaJIT. This update disables a
 specific optimization in LuaJIT that could potentially lead to severe
 performance degradation under certain circumstances ([CVE-2024-39702](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-39702)).
+We would like to express our gratitude to Kong Inc. for reporting this issue.
 
 [Download this version here](download.html).
 
@@ -19,7 +22,8 @@ This is the second OpenResty release based on the nginx [% major_ver %] core.
 
 # Version highlights
 
-* Applied a patch to LuaJIT addressing performance issues related to hash computation optimization.
+* Applied a patch to our OpenResty branch of LuaJIT addressing performance
+issues related to hash computation optimization.
 
 # Full Change logs
 

--- a/v2/en/ann-1025003002.md.tt2
+++ b/v2/en/ann-1025003002.md.tt2
@@ -9,7 +9,7 @@ We sincerely apologize for any confusion and want to clarify that this issue
 originates from our branch, not from upstream LuaJIT. This update disables a
 specific optimization in LuaJIT that could potentially lead to severe
 performance degradation under certain circumstances ([CVE-2024-39702](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-39702)).
-We would like to express our gratitude to Kong Inc. for reporting this issue.
+We would like to express our gratitude to Zhongwei Yao from Kong Inc. for reporting this issue.
 
 [Download this version here](download.html).
 

--- a/v2/en/changelog-1019009.md
+++ b/v2/en/changelog-1019009.md
@@ -7,7 +7,7 @@
 # Version 1.19.9.2 - 19 Jul 2024
 
 * upgraded [LuaJIT](https://github.com/openresty/luajit2) to 2.1-20210510.1.
-    * bugfix: disable hash computation optimization because of the possibility of severe degradation (CVE-2024-39702). This issue originates from the OpenResty LuaJIT branch. _Thanks Kong INC. for reporting the issue, and thanks lijunlong for the patch._
+    * bugfix: disable hash computation optimization because of the possibility of severe degradation (CVE-2024-39702). This issue originates from the OpenResty LuaJIT branch. _Thanks Zhongwei Yao from Kong INC. for reporting the issue, and thanks lijunlong for the patch._
 
 # Version 1.19.9.1 - 6 Aug 2021
 

--- a/v2/en/changelog-1019009.md
+++ b/v2/en/changelog-1019009.md
@@ -7,7 +7,7 @@
 # Version 1.19.9.2 - 19 Jul 2024
 
 * upgraded [LuaJIT](https://github.com/openresty/luajit2) to 2.1-20210510.1.
-    * bugfix: disable hash computation optimization because of the possibility of severe degradation (CVE-2024-39702). _Thanks lijunlong for the patch._
+    * bugfix: disable hash computation optimization because of the possibility of severe degradation (CVE-2024-39702). This issue originates from the OpenResty LuaJIT branch. _Thanks Kong INC. for reporting the issue, and thanks lijunlong for the patch._
 
 # Version 1.19.9.1 - 6 Aug 2021
 

--- a/v2/en/changelog-1021004.md
+++ b/v2/en/changelog-1021004.md
@@ -7,7 +7,7 @@
 # Version 1.21.4.4 - 19 Jul 2024
 
 * upgraded [LuaJIT](https://github.com/openresty/luajit2) to v2.1-20230410.1.
-    * bugfix: disable hash computation optimization because of the possibility of severe degradation (CVE-2024-39702). This issue originates from the OpenResty LuaJIT branch. _Thanks Kong INC. for reporting the issue, and thanks lijunlong for the patch._
+    * bugfix: disable hash computation optimization because of the possibility of severe degradation (CVE-2024-39702). This issue originates from the OpenResty LuaJIT branch. _Thanks Zhongwei Yao from Kong INC. for reporting the issue, and thanks lijunlong for the patch._
 
 # Version 1.21.4.3 - 7 Nov 2023
 

--- a/v2/en/changelog-1021004.md
+++ b/v2/en/changelog-1021004.md
@@ -7,7 +7,7 @@
 # Version 1.21.4.4 - 19 Jul 2024
 
 * upgraded [LuaJIT](https://github.com/openresty/luajit2) to v2.1-20230410.1.
-    * bugfix: disable hash computation optimization because of the possibility of severe degradation (CVE-2024-39702). _Thanks lijunlong for the patch._
+    * bugfix: disable hash computation optimization because of the possibility of severe degradation (CVE-2024-39702). This issue originates from the OpenResty LuaJIT branch. _Thanks Kong INC. for reporting the issue, and thanks lijunlong for the patch._
 
 # Version 1.21.4.3 - 7 Nov 2023
 

--- a/v2/en/changelog-1025003.md
+++ b/v2/en/changelog-1025003.md
@@ -7,7 +7,7 @@
 # Version 1.25.3.2 - 19 Jul 2024
 
 * upgraded [LuaJIT](https://github.com/openresty/luajit2) to v2.1-20231117.1
-    * bugfix: disable hash computation optimization because of the possibility of severe degradation (CVE-2024-39702). _Thanks lijunlong for the patch._
+    * bugfix: disable hash computation optimization because of the possibility of severe degradation (CVE-2024-39702). This issue originates from the OpenResty LuaJIT branch. _Thanks Kong INC. for reporting the issue, and thanks lijunlong for the patch._
 
 # Version 1.25.3.1 - 04 Jan 2024
 

--- a/v2/en/changelog-1025003.md
+++ b/v2/en/changelog-1025003.md
@@ -7,7 +7,7 @@
 # Version 1.25.3.2 - 19 Jul 2024
 
 * upgraded [LuaJIT](https://github.com/openresty/luajit2) to v2.1-20231117.1
-    * bugfix: disable hash computation optimization because of the possibility of severe degradation (CVE-2024-39702). This issue originates from the OpenResty LuaJIT branch. _Thanks Kong INC. for reporting the issue, and thanks lijunlong for the patch._
+    * bugfix: disable hash computation optimization because of the possibility of severe degradation (CVE-2024-39702). This issue originates from the OpenResty LuaJIT branch. _Thanks Zhongwei Yao from Kong INC. for reporting the issue, and thanks lijunlong for the patch._
 
 # Version 1.25.3.1 - 04 Jan 2024
 


### PR DESCRIPTION
… LuaJIT in the OpenResty branch.