### PR TITLE
Update apt prerequisites for modern ubuntu (26.04 LTS)

### DIFF
--- a/v2/en/installation.md
+++ b/v2/en/installation.md
@@ -97,8 +97,8 @@ PATH environment.
 You're recommended to install the following packages using apt-get:
 
 ```bash
-apt-get install libpcre3-dev \
-    libssl-dev perl make build-essential curl
+apt-get install libpcre2-dev libssl-dev \
+    perl make build-essential curl zlib1g-dev
 ```
 
 ### Fedora and RedHat users


### PR DESCRIPTION
Replaced `libpcre3-dev` with `libpcre2-dev` and added `zlib1g-dev` for compatibility with Ubuntu 26.04.

According to https://packages.ubuntu.com/, backwards-compatibility stays completely intact.