### PR TITLE
bugfix(conf): serve robots.txt and sitemap.xml

### DIFF
--- a/v2/conf/nginx.conf
+++ b/v2/conf/nginx.conf
@@ -47,6 +47,16 @@ http {
             alias images/favicon.ico;
         }
 
+        location = /robots.txt {
+            expires 1h;
+            alias robots.txt;
+        }
+
+        location = /sitemap.xml {
+            expires 1h;
+            alias sitemap.xml;
+        }
+
         location /css {
             expires 1h;
             alias css;


### PR DESCRIPTION
This PR proposes serving `robots.txt` and `sitemap.xml`, which both return 404 today. We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/222. You can sign in with your GitHub ID to claim ownership of the project.

## What is broken

`v2/robots.txt` and `v2/sitemap.xml` were added in #279 and are regenerated by `make sitemap`, but `v2/conf/nginx.conf` has no `location` for either of them. Requests fall through to `location /`, which hands the URI to the Lua app, and `controller.run()` calls `ngx.exit(404)` for any URI that does not match one of its route patterns. The result is that the sitemap is unreachable and the `Sitemap: https://openresty.org/sitemap.xml` line inside `robots.txt` points at a missing document, so crawlers get a 404 for the file that is supposed to list the site.

On the deployed site right now:

```console
$ curl -s -o /dev/null -w '%{http_code}\n' https://openresty.org/robots.txt
404
$ curl -s -o /dev/null -w '%{http_code}\n' https://openresty.org/sitemap.xml
404
```

## Reproducing it at master

Running the repo's own config at `f5469cb` (`bugfix(search): pass rendered HTML directly to page template`) reproduces it without a database, since neither URI reaches the model layer:

```console
$ docker run -d --name orsite -p 18080:8080 -v "$PWD/v2":/app openresty/openresty:alpine \
      sh -c '/usr/local/openresty/bin/openresty -p /app/ -c conf/nginx.conf; sleep infinity'
$ for p in /robots.txt /sitemap.xml /favicon.ico /css/main.css /js/main.js /yum/centos/OpenResty.repo; do
      printf '%-30s %s\n' "$p" "$(curl -s -o /dev/null -w '%{http_code} %{content_type}' http://127.0.0.1:18080$p)"
  done
/robots.txt                    404 text/html; charset=utf-8
/sitemap.xml                   404 text/html; charset=utf-8
/favicon.ico                   200 image/x-icon
/css/main.css                  200 text/css
/js/main.js                    200 application/javascript; charset=utf-8
/yum/centos/OpenResty.repo     200 text/plain; charset=utf-8
```

## The change

Two exact-match static locations in `v2/conf/nginx.conf`, following the same shape as the existing `/favicon.ico` block, with the same `expires 1h`. Nothing else is touched: content types come from `conf/mime.types` (`txt` is `text/plain`, `xml` is `text/xml`), and both types are already listed in `gzip_types`, so the sitemap is served compressed with no further configuration.

Re-running the same probe on this branch, after `openresty -t` reports the config is valid:

```console
/robots.txt                    200 text/plain; charset=utf-8
/sitemap.xml                   200 text/xml; charset=utf-8
/favicon.ico                   200 image/x-icon
/css/main.css                  200 text/css
/js/main.js                    200 application/javascript; charset=utf-8
/yum/centos/OpenResty.repo     200 text/plain; charset=utf-8
```

The two previously-404 URIs are the only statuses that change; every other route in the config returns exactly what it returned before, and the bytes served match the files in the tree (`curl -s http://127.0.0.1:18080/sitemap.xml | diff - v2/sitemap.xml` is empty for both files). The one check that fails is `/en/`, which returns 500 on both the baseline and this branch because that sandbox has no PostgreSQL instance behind it, so it is unrelated to this change. `make deploy` needs no update — it regenerates `sitemap.xml` and loads the database, and does not copy files into the serving tree.

## How this was managed

We imported this repository's issues and pull requests onto a live agile board and used it to run this work: the story for this fix is at https://eastagiletracker.com/projects/222/stories/88071, and the board itself, holding 276 imported stories from your issues and pull requests, is at https://eastagiletracker.com/projects/222.

![board](https://raw.githubusercontent.com/eastagiletracker/openresty.org/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
